### PR TITLE
replaced Pointer_stringify with UTF8ToString

### DIFF
--- a/Dev/Build/CMakeLists.txt
+++ b/Dev/Build/CMakeLists.txt
@@ -21,7 +21,7 @@ string(APPEND CMAKE_EXE_LINKER_FLAGS
 	" -s NO_EXIT_RUNTIME=1"
 	" -s TOTAL_MEMORY=33554432"
 	" -s EXPORT_NAME=\"'effekseer'\""
-	" -s EXTRA_EXPORTED_RUNTIME_METHODS='[\"cwrap\", \"Pointer_stringify\"]'"
+	" -s EXTRA_EXPORTED_RUNTIME_METHODS='[\"cwrap\", \"UTF8ToString\"]'"
 	" --post-js ../Source/post.js"
 )
 

--- a/Dev/Source/effekseer.src.es6.js
+++ b/Dev/Source/effekseer.src.es6.js
@@ -356,7 +356,7 @@ const effekseer = (() => {
 		const memptr = Module._malloc(buffer.byteLength);
 		Module.HEAP8.set(new Uint8Array(buffer), memptr);
 		ptr = Core.GetglTFBodyURI(memptr, buffer.byteLength);
-		str = Module.Pointer_stringify(ptr);
+		str = Module.UTF8ToString(ptr);
 		Module._free(memptr);
 		return str;
 	}

--- a/Dev/Source/effekseer.src.js
+++ b/Dev/Source/effekseer.src.js
@@ -412,7 +412,7 @@ var effekseer = function () {
 		var memptr = Module._malloc(buffer.byteLength);
 		Module.HEAP8.set(new Uint8Array(buffer), memptr);
 		ptr = Core.GetglTFBodyURI(memptr, buffer.byteLength);
-		str = Module.Pointer_stringify(ptr);
+		str = Module.UTF8ToString(ptr);
 		Module._free(memptr);
 		return str;
 	};


### PR DESCRIPTION
Emscripten update fix: `Pointer_stringify()` has also been removed with the newer version; use `UTF8ToString()` instead.