### PR TITLE
feat: add EffekseerHandle#setFrame api

### DIFF
--- a/Release/effekseer.d.ts
+++ b/Release/effekseer.d.ts
@@ -362,6 +362,12 @@ declare namespace effekseer {
         readonly exists: boolean;
 
         /**
+         * Set frame of this effect instance.
+         * @param {number} frame Frame of this effect instance.
+         */
+        setFrame(frame: number): void;
+
+        /**
          * Set the location of this effect instance.
          * @param {number} x X value of location
          * @param {number} y Y value of location

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -386,6 +386,11 @@ extern "C"
 
 	int EXPORT EffekseerExists(EfkWebViewer::Context* context, int handle) { return context->manager->Exists(handle) ? 1 : 0; }
 
+	void EXPORT EffekseerSetFrame(EfkWebViewer::Context* context, int handle, float frame)
+	{
+		context->manager->UpdateHandleToMoveToFrame(handle, frame);
+	}
+
 	void EXPORT EffekseerSetLocation(EfkWebViewer::Context* context, int handle, float x, float y, float z)
 	{
 		context->manager->SetLocation(handle, x, y, z);

--- a/src/js/effekseer.src.js
+++ b/src/js/effekseer.src.js
@@ -32,6 +32,7 @@ const effekseer = (() => {
       StopEffect: Module.cwrap("EffekseerStopEffect", "void", ["number", "number"]),
       StopRoot: Module.cwrap("EffekseerStopRoot", "void", ["number", "number"]),
       Exists: Module.cwrap("EffekseerExists", "number", ["number", "number"]),
+      SetFrame: Module.cwrap("EffekseerSetFrame", "void", ["number", "number", "number"]),
       SetLocation: Module.cwrap("EffekseerSetLocation", "void", ["number", "number", "number", "number", "number"]),
       SetRotation: Module.cwrap("EffekseerSetRotation", "void", ["number", "number", "number", "number", "number"]),
       SetScale: Module.cwrap("EffekseerSetScale", "void", ["number", "number", "number", "number", "number"]),
@@ -298,6 +299,14 @@ const effekseer = (() => {
      */
     get exists() {
       return !!Core.Exists(this.context.nativeptr, this.native);
+    }
+
+    /**
+     * Set frame of this effect instance.
+     * @param {number} frame Frame of this effect instance.
+     */
+    setFrame(frame) {
+      Core.SetFrame(this.context.nativeptr, this.native, frame);
     }
 
     /**


### PR DESCRIPTION
This PR is for #76.

I also want to add `EffekseerHandle#getFrame`(get the current frame of effect instance), but I can't find a simple method in the main repository.