### PR TITLE
Fix type of 'data' parameter of loadEffect to allow ArrayBuffer

### DIFF
--- a/Release/effekseer.d.ts
+++ b/Release/effekseer.d.ts
@@ -122,10 +122,10 @@ declare namespace effekseer {
      * @param {function=} onerror A function that is called at loading error. First argument is a message. Second argument is an url.
      * @returns {EffekseerEffect} The effect data
      */
-    export function loadEffect(path: string, scale?: number, onload?: () => void, onerror?: (reason: string, path: string) => void): EffekseerEffect;
+    export function loadEffect(data: string|ArrayBuffer, scale?: number, onload?: () => void, onerror?: (reason: string, path: string) => void): EffekseerEffect;
     /**
      * Load the effect package file (resources included in the package).
-     * @param {string|ArrayBuffer} data A URL/ArrayBuffer of effect file (*.efk)
+     * @param {string|ArrayBuffer} data A URL/ArrayBuffer of effect package file (*.efkpkg)
      * @param {Object} Unzip An Unzip object.
      * @param {number} scale A magnification rate for the effect. The effect is loaded magnificating with this specified number.
      * @param {function=} onload A function that is called at loading complete

--- a/src/js/effekseer.src.js
+++ b/src/js/effekseer.src.js
@@ -923,15 +923,15 @@ const effekseer = (() => {
     }
 
     /**
-     * Load the effect data file (and resources).
-     * @param {string|ArrayBuffer} path A URL/ArrayBuffer of effect package file (*.efkpkg)
+     * Load the effect package file (resources included in the package).
+     * @param {string|ArrayBuffer} data A URL/ArrayBuffer of effect package file (*.efkpkg)
      * @param {Object} Unzip a Unzip object
      * @param {number} scale A magnification rate for the effect. The effect is loaded magnificating with this specified number.
      * @param {function=} onload A function that is called at loading complete
      * @param {function=} onerror A function that is called at loading error. First argument is a message. Second argument is an url.
      * @returns {EffekseerEffect} The effect data
      */
-    loadEffectPackage(path, Unzip, scale = 1.0, onload, onerror) {
+    loadEffectPackage(data, Unzip, scale = 1.0, onload, onerror) {
       if (Unzip == null)
       this._makeContextCurrent();
 
@@ -939,15 +939,15 @@ const effekseer = (() => {
       effect.scale = scale;
       effect.onload = onload;
       effect.onerror = onerror;
-      
-      if (typeof path === "string") {
-        const dirIndex = path.lastIndexOf("/");
-        effect.baseDir = (dirIndex >= 0) ? path.slice(0, dirIndex + 1) : "";
-        _loadBinFile(path, buffer => {
+
+      if (typeof data === "string") {
+        const dirIndex = data.lastIndexOf("/");
+        effect.baseDir = (dirIndex >= 0) ? data.slice(0, dirIndex + 1) : "";
+        _loadBinFile(data, buffer => {
           effect._loadFromPackage(buffer, Unzip);
         }, effect.onerror);
-      } else if (path instanceof ArrayBuffer) {
-        const buffer = path;
+      } else if (data instanceof ArrayBuffer) {
+        const buffer = data;
         effect._loadFromPackage(buffer, Unzip);
       }
 


### PR DESCRIPTION
The `loadEffect` function allows either a URL (`string`) or an `ArrayBuffer`, but the types in `effekseer.d.ts` only allowed `string`. This PR updates the type to allow either, matching the JavaScript code.

The naming and comments also weren't quite in sync between the two, one naming it `data` while the other calling it `path`. Updated the code to consistently use `data` in this case as it might not be a path. Functionality has been left unchanged.