### PR TITLE
Fix restore vao bug bewteen js and native

### DIFF
--- a/src/js/effekseer.src.js
+++ b/src/js/effekseer.src.js
@@ -532,12 +532,20 @@ const effekseer = (() => {
       this.current_active_texture_id = null;
 
       this.ext_vao = this._gl.getExtension('OES_vertex_array_object');
+      let vao = null;
       if (this.ext_vao != null) {
-        this.effekseer_vao = this.ext_vao.createVertexArrayOES();
+        vao = this.ext_vao.createVertexArrayOES();
       }
       else if ('createVertexArray' in this._gl) {
         this.isWebGL2VAOEnabled = true;
-        this.effekseer_vao = this._gl.createVertexArray();
+        vao = this._gl.createVertexArray();
+      }
+      if (vao) {
+        let GL = Module.GL;
+        let id = GL.getNewId(GL.vaos);
+        vao.name = id;
+        GL.vaos[id] = vao;
+        this.effekseer_vao = vao;
       }
     }
 


### PR DESCRIPTION
GL object is managed by wasm js scipt, Each GL object created in native has an unique id generated in wasm.js. 

**wasm.js**
```
var _glGenBuffers = (n, buffers) => {
  __glGenObject(n, buffers, 'createBuffer', GL.buffers
    );
};

var __glGenObject = (n, buffers, createFunction, objectTable) => {
  for (var i = 0; i < n; i++) {
    var buffer = GLctx[createFunction]();
    var id = buffer && GL.getNewId(objectTable);
    if (buffer) {
      buffer.name = id;
      objectTable[id] = buffer;
    } else {
      GL.recordError(0x502 /* GL_INVALID_OPERATION */);
    }
    HEAP32[(((buffers)+(i*4))>>2)] = id;
  }
 };


var _glGetIntegerv = (name_, p) => {
   emscriptenWebGLGet(name_, p, 0);
};

var emscriptenWebGLGet = (name_, p, type) => {
    ...
    var result = GLctx.getParameter(name_);
    ...
    ret = result.name | 0;
    ...
}
```

This explains why create and bind buffer in js but get 0 in native glGetIntegerv.