### PR TITLE
Update artifact upload action to v4

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -125,7 +125,7 @@ jobs:
             outfile_js.write(data_es5)
             outfile_min_js.write(jsmin.jsmin(data_es5))
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: EffekseerForWebGL170
         path: Release
@@ -144,7 +144,7 @@ jobs:
         cd tests
         python3 take_screenshot.py
   
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: screenshots
         path: tests/screenshots


### PR DESCRIPTION
## Summary
- update both artifact upload steps in package workflow to use the maintained v4 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9e9ff30c832a8af47a876f4dd0cf