### PR TITLE
Upgrade emsdk dependency to 3.1.57 for CI

### DIFF
--- a/scripts/clone_dependencies.sh
+++ b/scripts/clone_dependencies.sh
@@ -1,4 +1,9 @@
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
-./emsdk install sdk-1.39.14-64bit
-./emsdk activate sdk-1.39.14-64bit
+
+# Install a modern Emscripten SDK that ships macOS arm64 binaries so CI
+# runners no longer fall back to Rosetta for legacy toolchains.
+EMSDK_VERSION=3.1.57
+
+./emsdk install "${EMSDK_VERSION}"
+./emsdk activate "${EMSDK_VERSION}"


### PR DESCRIPTION
## Summary
- switch the dependency setup script to install emsdk 3.1.57, which includes macOS arm64 binaries
- simplify the script now that Rosetta fallbacks are unnecessary

## Testing
- bash -n scripts/clone_dependencies.sh

------
https://chatgpt.com/codex/tasks/task_e_68dfa06ffdc0832ab7d6b2147dd3fd92