### PR TITLE
Update CMake to use C++17

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,8 @@ string(APPEND CMAKE_CXX_FLAGS
   " --memory-init-file 0"
 )
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set linker flags
 


### PR DESCRIPTION
## Summary
- set the project C++ standard to 17 so headers using std::variant build correctly

## Testing
- cmake -S src -B build

------
https://chatgpt.com/codex/tasks/task_e_68dfac292cc0832a855e30219306bd32