### PR TITLE
Fix EffekseerRendererGL integration paths

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ file(GLOB effekseer_src
   ${EFFEKSEER_DIR}/Dev/Cpp/Effekseer/Effekseer/Model/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/Effekseer/Effekseer/Noise/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererCommon/*.cpp
-  ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererGL/EffekseerRenderer/*.cpp
+  ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererGL/EffekseerRendererGL/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/Common/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/OpenGL/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/GLSLGenerator/*.cpp

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -2,9 +2,9 @@
 #include "EffekseerRendererGL.h"
 #include "EffekseerSoundAL.h"
 #include <AL/alc.h>
-#include <EffekseerRenderer/EffekseerRendererGL.MaterialLoader.h>
-#include <EffekseerRenderer/EffekseerRendererGL.RendererImplemented.h>
-#include <EffekseerRenderer/GraphicsDevice.h>
+#include <EffekseerRendererGL/EffekseerRendererGL.MaterialLoader.h>
+#include <EffekseerRendererGL/EffekseerRendererGL.RendererImplemented.h>
+#include <EffekseerRendererGL/GraphicsDevice.h>
 
 #include <algorithm>
 #include <emscripten.h>


### PR DESCRIPTION
## Summary
- update WebGL entry point to include EffekseerRendererGL headers from their new locations
- adjust the CMake file glob so the renamed EffekseerRendererGL sources are compiled

## Testing
- python3 build.py --help *(fails: missing `command` wrapper in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfae47d6ec832a8e6ac8693ba41ff0