### PR TITLE
Fix build by including renderer common sources

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ file(GLOB effekseer_src
   ${EFFEKSEER_DIR}/Dev/Cpp/Effekseer/Effekseer/Model/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/Effekseer/Effekseer/Noise/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererCommon/*.cpp
+  ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererCommon/EffekseerRendererCommon/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererGL/EffekseerRendererGL/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/Common/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/OpenGL/*.cpp


### PR DESCRIPTION
## Summary
- include the EffekseerRendererCommon sources located in the nested directory so they are compiled

## Testing
- not run (emscripten toolchain not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfb1a9b5b0832aab800780f20721cf