### PR TITLE
Fix missing EffekseerSoundAL sources in build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ file(GLOB effekseer_src
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/Common/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/OpenGL/*.cpp
   ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerMaterialCompiler/GLSLGenerator/*.cpp
-  ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerSoundAL/EffekseerSound/*.cpp
+  ${EFFEKSEER_DIR}/Dev/Cpp/EffekseerSoundAL/EffekseerSoundAL/*.cpp
   ${PROJECT_SOURCE_DIR}/cpp/*.cpp
 )
 


### PR DESCRIPTION
## Summary
- update the CMake source glob so that the EffekseerSoundAL sources are included in the build

## Testing
- not run (emscripten toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb3d7d978832a9c2bf69e33bf20d1