### PR TITLE
Fix CI Python setup failure on macOS

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,9 +43,9 @@ jobs:
         make
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.10'
         architecture: 'x64'
 
     - name: pip


### PR DESCRIPTION
## Summary
- update the package workflow to use actions/setup-python@v5 with Python 3.10 to avoid the macOS gettext failure when installing Python 3.7

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfb76125f4832a85952cfa6f08452e