### PR TITLE
Fix macOS CI Python setup

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -41,10 +41,10 @@ jobs:
         make
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
-        architecture: 'x64'
+        python-version: '3.10'
+        architecture: 'arm64'
 
     - name: pip
       shell: bash
@@ -131,16 +131,16 @@ jobs:
     - name: pip
       shell: bash
       run: |
-        python3 -m pip install --upgrade pip
-        pip3 install chromedriver-binary==105.0.5195.19.0
-        pip3 install selenium==4.4.3
-        pip3 install requests
+        python -m pip install --upgrade pip
+        python -m pip install chromedriver-binary==105.0.5195.19.0
+        python -m pip install selenium==4.4.3
+        python -m pip install requests
 
     - name: test
       shell: bash
       run: |
         cd tests
-        python3 take_screenshot.py
+        python take_screenshot.py
   
     - uses: actions/upload-artifact@v1
       with:
@@ -151,4 +151,4 @@ jobs:
       shell: bash
       run: |
         cd tests
-        python3 test.py
+        python test.py


### PR DESCRIPTION
## Summary
- switch the package workflow to install the arm64 build of Python 3.10 via actions/setup-python@v5 to avoid missing gettext
- ensure subsequent pip installs and Python test steps use the configured interpreter

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfb9231d70832a833c9a337a646bd3