### PR TITLE
Fix screenshot test waiting for dynamic buttons

### DIFF
--- a/tests/take_screenshot.py
+++ b/tests/take_screenshot.py
@@ -1,9 +1,11 @@
 import unittest
 import os
-import time
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
 import shutil
 import filecmp
 import base64
@@ -59,15 +61,14 @@ class DisplayTest(unittest.TestCase):
         # requests.post('https://echo.effekseer.org', files=files)
 
     def test_some_effects(self):
+        wait = WebDriverWait(self.browser, 30)
         for path in self.files:
             name = os.path.basename(path)
             self.browser.get("file://"+ os.path.abspath('index.html'))
-            time.sleep(1)
-            self.browser.find_element(By.ID, name).click()
-            time.sleep(1)
+            wait.until(EC.element_to_be_clickable((By.ID, name))).click()
             for step in range(1) :
                 with self.subTest(name=name) :
-                    self.browser.find_element(By.ID, 'step').click()
+                    wait.until(EC.element_to_be_clickable((By.ID, 'step'))).click()
                     time.sleep(1)
                     with open('screenshots/' + name +'_step' + str(step) + '.png', 'wb') as f:
                         f.write(self.capturePng())


### PR DESCRIPTION
## Summary
- add Selenium WebDriver waits to ensure dynamically created buttons are clickable before interacting
- keep step execution reliable by waiting for the control before every capture

## Testing
- python3 take_screenshot.py *(fails: ModuleNotFoundError: No module named 'selenium' in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc167931c832ab83c79791c2075e3