### PR TITLE
Fix Selenium Chrome logging configuration for screenshot tests

### DIFF
--- a/tests/take_screenshot.py
+++ b/tests/take_screenshot.py
@@ -3,7 +3,6 @@ import os
 import time
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 import shutil
 import filecmp
 import base64
@@ -43,10 +42,9 @@ class DisplayTest(unittest.TestCase):
         options.add_argument('--enable-asm-webassembly')
         options.add_argument('--headless')
 
-        d = DesiredCapabilities.CHROME
-        d['goog:loggingPrefs'] = { 'browser':'ALL' }
+        options.set_capability('goog:loggingPrefs', { 'browser':'ALL' })
 
-        self.browser = webdriver.Chrome(options=options, desired_capabilities=d)
+        self.browser = webdriver.Chrome(options=options)
         self.browser.set_window_size(320, 320)
 
     @classmethod


### PR DESCRIPTION
## Summary
- configure the Selenium Chrome options using set_capability instead of deprecated desired_capabilities
- initialize the WebDriver with options only to remain compatible with Selenium 4

## Testing
- Not run (requires Chrome/Chromedriver which is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfc9711928832ab0b903d27220b47d