### PR TITLE
Fix missing runtime methods after Emscripten upgrade

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ if(AS_WASM)
       " -s ALLOW_MEMORY_GROWTH=1"
       " -s EXPORT_NAME=\"'effekseer_native'\""
       " -s EXPORTED_FUNCTIONS=\"['_malloc', '_free']\" "
-      " -s EXTRA_EXPORTED_RUNTIME_METHODS=\"['cwrap', 'UTF8ToString']\" "
+      " -s EXTRA_EXPORTED_RUNTIME_METHODS=\"['cwrap', 'UTF8ToString', 'UTF16ToString', 'stackSave', 'stackRestore', 'stackAlloc']\" "
       " --post-js ${PROJECT_SOURCE_DIR}/js/post.js"
     )
 
@@ -47,7 +47,7 @@ else()
       " -s ALLOW_MEMORY_GROWTH=1"
       " -s EXPORT_NAME=\"'effekseer'\""
       " -s EXPORTED_FUNCTIONS=\"['_malloc', '_free']\" "
-      " -s EXTRA_EXPORTED_RUNTIME_METHODS=\"['cwrap', 'UTF8ToString']\" "
+      " -s EXTRA_EXPORTED_RUNTIME_METHODS=\"['cwrap', 'UTF8ToString', 'UTF16ToString', 'stackSave', 'stackRestore', 'stackAlloc']\" "
       " --post-js ${PROJECT_SOURCE_DIR}/js/post.js"
     )
 

--- a/src/cpp/CustomFile.h
+++ b/src/cpp/CustomFile.h
@@ -39,7 +39,7 @@ public:
 	Effekseer::FileReaderRef OpenRead(const EFK_CHAR* path, bool isRequired)
 	{
 		// Request to load file
-		int loaded = EM_ASM_INT({ return Module._loadBinary(UTF16ToString($0), $1) != null; }, path, isRequired);
+		int loaded = EM_ASM_INT({ return Module._loadBinary(Module.UTF16ToString($0), $1) != null; }, path, isRequired);
 		if (!loaded)
 		{
 			return nullptr;
@@ -51,7 +51,7 @@ public:
 		// Copy data from arraybuffer
 		EM_ASM_INT(
 			{
-				var buffer = Module._loadBinary(UTF16ToString($0), $3);
+				var buffer = Module._loadBinary(Module.UTF16ToString($0), $3);
 				var memptr = _malloc(buffer.byteLength);
 				HEAP8.set(new Uint8Array(buffer), memptr);
 				setValue($1, memptr, "i32");

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -65,7 +65,7 @@ public:
 	{
 
 		// Request to load image
-		int loaded = EM_ASM_INT({ return Module._loadImage(UTF16ToString($0)) != null; }, path);
+               int loaded = EM_ASM_INT({ return Module._loadImage(Module.UTF16ToString($0)) != null; }, path);
 		if (!loaded)
 		{
 			// Loading incompleted
@@ -80,7 +80,7 @@ public:
 			{
 				var binding = GLctx.getParameter(GLctx.TEXTURE_BINDING_2D);
 
-				var img = Module._loadImage(UTF16ToString($0));
+                               var img = Module._loadImage(Module.UTF16ToString($0));
 				GLctx.bindTexture(GLctx.TEXTURE_2D, GL.textures[$1]);
 
 				var pa = gl.getParameter(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL);


### PR DESCRIPTION
## Summary
- export additional runtime helpers required by newer Emscripten builds
- update custom file and texture loaders to reference Module.UTF16ToString

## Testing
- not run (emscripten toolchain not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e09152ac10832ab51ffbf4ac0b9af3