### PR TITLE
Add experimental WebGPU runtime and Three.js sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build_asmjs
 build_wasm
+build_webgpu_threejs
 Release
 !Release/effekseer.d.ts

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ For more information
 
 - [How to build](docs/HowToBuild.md)
 
+- [WebGPU Three.js smoke](docs/WebGPUThreeJS.md)
+
 ## CI build (emsdk 1.38.11)
 
 This matches the GitHub Actions workflow in `.github/workflows/emsdk-1.38.11.yml`.

--- a/docs/WebGPUThreeJS.md
+++ b/docs/WebGPUThreeJS.md
@@ -1,10 +1,15 @@
 # WebGPU Three.js Smoke
 
 This repository's release wrapper remains the WebGL package. The WebGPU path is
-validated through the Effekseer WebGPU renderer in the `Effekseer` submodule and
-the LLGI WebGPU backend.
+available here as an experimental browser module and sample backed by the
+Effekseer WebGPU renderer in the `Effekseer` submodule and the maintained LLGI
+WebGPU backend.
 
-The smoke target added here builds a browser-only Emscripten test that:
+The WebGPU workflow added here builds two browser-only Emscripten targets:
+
+- `EffekseerForWebGPUThreeJsRuntime.js`, a small JavaScript-facing runtime used
+  by `threejs_webgpu_sample.html`
+- `EffekseerForWebGPUThreeJsSmoke.html`, an automated regression smoke
 
 - creates a browser WebGPU device through `navigator.gpu`
 - loads actual Three.js and creates a `THREE.PerspectiveCamera`
@@ -28,6 +33,10 @@ source /path/to/emsdk/emsdk_env.sh
 bash scripts/build_webgpu_threejs_smoke.sh
 ```
 
+The helper checks out the merged LLGI WebGPU browser-runner revision
+`6e8ddc6054cfdaeb6da6551e3b24e106c4ca85bc` while building and restores the
+submodule revision afterwards.
+
 To save a screenshot of the browser proof page:
 
 ```bash
@@ -38,9 +47,15 @@ bash scripts/build_webgpu_threejs_smoke.sh \
 A successful run ends with:
 
 ```text
-EFFEKSEER_WEBGPU_THREEJS_SMOKE_PASS completed changedPixels=...
+EFFEKSEER_WEBGPU_THREEJS_RUNNER_PASS completed changedPixels=...
 ```
 
-This workflow expects the LLGI WebGPU backend to be present in the maintained
-LLGI repository. At the time this workflow was added, the portable browser
-runner fix for that backend had been merged in `effekseer/LLGI` as PR #7.
+The generated sample files are written into `build_webgpu_threejs/`:
+
+- `EffekseerForWebGPUThreeJsRuntime.js`
+- `EffekseerForWebGPUThreeJsRuntime.wasm`
+- `effekseer.webgpu.js`
+- `threejs_webgpu_sample.html`
+
+Serve `build_webgpu_threejs/threejs_webgpu_sample.html` from localhost to try
+the WebGPU runtime surface manually.

--- a/docs/WebGPUThreeJS.md
+++ b/docs/WebGPUThreeJS.md
@@ -1,0 +1,46 @@
+# WebGPU Three.js Smoke
+
+This repository's release wrapper remains the WebGL package. The WebGPU path is
+validated through the Effekseer WebGPU renderer in the `Effekseer` submodule and
+the LLGI WebGPU backend.
+
+The smoke target added here builds a browser-only Emscripten test that:
+
+- creates a browser WebGPU device through `navigator.gpu`
+- loads actual Three.js and creates a `THREE.PerspectiveCamera`
+- passes that camera's projection and view matrices into the Effekseer WebGPU renderer
+- plays an Effekseer effect from preloaded test data
+- reads back the offscreen WebGPU render texture and fails if the effect does not change the frame
+
+## Requirements
+
+- Emscripten 4.x or newer with `--use-port=emdawnwebgpu`
+- CMake 3.15 or newer
+- Node.js 22 or newer
+- WebGPU-capable Chrome or Edge
+
+Set `CHROME_PATH` if Chrome is not in a common desktop install location.
+
+## Run
+
+```bash
+source /path/to/emsdk/emsdk_env.sh
+bash scripts/build_webgpu_threejs_smoke.sh
+```
+
+To save a screenshot of the browser proof page:
+
+```bash
+bash scripts/build_webgpu_threejs_smoke.sh \
+  --screenshot=/tmp/effekseer-webgpu-threejs.png
+```
+
+A successful run ends with:
+
+```text
+EFFEKSEER_WEBGPU_THREEJS_SMOKE_PASS completed changedPixels=...
+```
+
+This workflow expects the LLGI WebGPU backend to be present in the maintained
+LLGI repository. At the time this workflow was added, the portable browser
+runner fix for that backend had been merged in `effekseer/LLGI` as PR #7.

--- a/scripts/build_webgpu_threejs_smoke.sh
+++ b/scripts/build_webgpu_threejs_smoke.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-${ROOT_DIR}/build_webgpu_threejs}"
+
+if ! command -v emcmake >/dev/null 2>&1; then
+  echo "emcmake was not found. Activate an Emscripten 4.x SDK before running this script." >&2
+  exit 2
+fi
+
+git -C "${ROOT_DIR}" submodule update --init --depth 1 Effekseer TestData ResourceData
+git -C "${ROOT_DIR}/Effekseer" submodule update --init --depth 1 Dev/Cpp/3rdParty/LLGI Dev/Cpp/3rdParty/spdlog Dev/Cpp/3rdParty/stb TestData ResourceData
+
+emcmake cmake -S "${ROOT_DIR}/webgpu" -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Release
+cmake --build "${BUILD_DIR}" --target EffekseerForWebGPUThreeJsSmoke -j "${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)}"
+
+node "${ROOT_DIR}/webgpu/run_webgpu_threejs_smoke.mjs" \
+  "${BUILD_DIR}/EffekseerForWebGPUThreeJsSmoke.html" \
+  "$@"

--- a/scripts/build_webgpu_threejs_smoke.sh
+++ b/scripts/build_webgpu_threejs_smoke.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-${ROOT_DIR}/build_webgpu_threejs}"
+LLGI_WEBGPU_REV="${LLGI_WEBGPU_REV:-6e8ddc6054cfdaeb6da6551e3b24e106c4ca85bc}"
 
 if ! command -v emcmake >/dev/null 2>&1; then
   echo "emcmake was not found. Activate an Emscripten 4.x SDK before running this script." >&2
@@ -12,9 +13,29 @@ fi
 git -C "${ROOT_DIR}" submodule update --init --depth 1 Effekseer TestData ResourceData
 git -C "${ROOT_DIR}/Effekseer" submodule update --init --depth 1 Dev/Cpp/3rdParty/LLGI Dev/Cpp/3rdParty/spdlog Dev/Cpp/3rdParty/stb TestData ResourceData
 
+LLGI_DIR="${ROOT_DIR}/Effekseer/Dev/Cpp/3rdParty/LLGI"
+ORIGINAL_LLGI_REV="$(git -C "${LLGI_DIR}" rev-parse HEAD)"
+if [ -n "$(git -C "${LLGI_DIR}" status --porcelain)" ]; then
+  echo "LLGI submodule has local changes; refusing to switch revisions for the WebGPU smoke." >&2
+  exit 2
+fi
+
+restore_llgi_revision() {
+  git -C "${LLGI_DIR}" checkout -q --detach "${ORIGINAL_LLGI_REV}" >/dev/null 2>&1 || true
+}
+trap restore_llgi_revision EXIT
+
+git -C "${LLGI_DIR}" fetch --depth 1 origin "${LLGI_WEBGPU_REV}"
+git -C "${LLGI_DIR}" checkout -q --detach "${LLGI_WEBGPU_REV}"
+echo "Using LLGI WebGPU revision ${LLGI_WEBGPU_REV}"
+
 emcmake cmake -S "${ROOT_DIR}/webgpu" -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Release
-cmake --build "${BUILD_DIR}" --target EffekseerForWebGPUThreeJsSmoke -j "${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)}"
+cmake --build "${BUILD_DIR}" --target EffekseerForWebGPUThreeJsSmoke EffekseerForWebGPUThreeJsRuntimeAssets -j "${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)}"
 
 node "${ROOT_DIR}/webgpu/run_webgpu_threejs_smoke.mjs" \
   "${BUILD_DIR}/EffekseerForWebGPUThreeJsSmoke.html" \
+  "$@"
+
+node "${ROOT_DIR}/webgpu/run_webgpu_threejs_smoke.mjs" \
+  "${BUILD_DIR}/threejs_webgpu_sample.html" \
   "$@"

--- a/webgpu/CMakeLists.txt
+++ b/webgpu/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(EffekseerForWebGPUThreeJsSmoke C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+get_filename_component(EFFEKSEER_FOR_WEBGL_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+set(EFFEKSEER_DIR "${EFFEKSEER_FOR_WEBGL_ROOT}/Effekseer")
+list(APPEND CMAKE_MODULE_PATH "${EFFEKSEER_DIR}/cmake")
+
+if(NOT EMSCRIPTEN)
+  message(FATAL_ERROR "The WebGPU Three.js smoke target requires Emscripten.")
+endif()
+
+include(FilterFolder)
+include(ClangFormat)
+include(LinkAppleLibs)
+
+set(BUILD_VIEWER OFF CACHE BOOL "" FORCE)
+set(BUILD_EDITOR OFF CACHE BOOL "" FORCE)
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(BUILD_TOOLS OFF CACHE BOOL "" FORCE)
+set(BUILD_TEST ON CACHE BOOL "" FORCE)
+set(BUILD_GL OFF CACHE BOOL "" FORCE)
+set(BUILD_WEBGPU ON CACHE BOOL "" FORCE)
+set(BUILD_WEBGPU_BROWSER_TEST ON CACHE BOOL "" FORCE)
+set(BUILD_DX9 OFF CACHE BOOL "" FORCE)
+set(BUILD_DX11 OFF CACHE BOOL "" FORCE)
+set(BUILD_DX12 OFF CACHE BOOL "" FORCE)
+set(BUILD_METAL OFF CACHE BOOL "" FORCE)
+set(BUILD_VULKAN OFF CACHE BOOL "" FORCE)
+set(USE_OPENAL OFF CACHE BOOL "" FORCE)
+set(CLANG_FORMAT_ENABLED OFF CACHE BOOL "" FORCE)
+
+add_subdirectory("${EFFEKSEER_DIR}/Dev/Cpp" "${CMAKE_CURRENT_BINARY_DIR}/Effekseer")
+
+if(TARGET EffekseerRendererLLGI)
+  target_include_directories(
+    EffekseerRendererLLGI
+    PUBLIC "${EFFEKSEER_DIR}/Dev/Cpp/3rdParty/LLGI/src"
+  )
+endif()
+
+add_executable(EffekseerForWebGPUThreeJsSmoke threejs_smoke.cpp)
+target_link_libraries(EffekseerForWebGPUThreeJsSmoke PRIVATE TestRuntimeFramework)
+target_include_directories(
+  EffekseerForWebGPUThreeJsSmoke
+  PRIVATE
+    "${EFFEKSEER_DIR}/Dev/Cpp/TestRuntimeFramework"
+    "${EFFEKSEER_DIR}/Dev/Cpp/Effekseer"
+    "${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererCommon"
+    "${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererLLGI"
+    "${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererWebGPU"
+    "${EFFEKSEER_DIR}/Dev/Cpp/3rdParty/LLGI/src"
+)
+
+set_target_properties(EffekseerForWebGPUThreeJsSmoke PROPERTIES SUFFIX ".html")
+target_link_options(
+  EffekseerForWebGPUThreeJsSmoke
+  PRIVATE
+    "--pre-js=${CMAKE_CURRENT_SOURCE_DIR}/pre_effekseer_webgpu_threejs_smoke.js"
+    "--preload-file=${EFFEKSEER_DIR}/TestData@/TestData"
+    "-sALLOW_MEMORY_GROWTH=1"
+    "-sASYNCIFY=1"
+    "-sASSERTIONS=1"
+)
+
+add_custom_command(
+  TARGET EffekseerForWebGPUThreeJsSmoke
+  POST_BUILD
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${EFFEKSEER_FOR_WEBGL_ROOT}/docs/Sample/three.min.js"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsSmoke>/three.min.js"
+)
+
+enable_testing()
+find_program(NODE_EXE node)
+if(NODE_EXE)
+  add_test(
+    NAME EffekseerForWebGPU_ThreeJsSmoke
+    COMMAND
+      ${NODE_EXE}
+      "${CMAKE_CURRENT_SOURCE_DIR}/run_webgpu_threejs_smoke.mjs"
+      "$<TARGET_FILE:EffekseerForWebGPUThreeJsSmoke>"
+  )
+endif()

--- a/webgpu/CMakeLists.txt
+++ b/webgpu/CMakeLists.txt
@@ -55,6 +55,19 @@ target_include_directories(
     "${EFFEKSEER_DIR}/Dev/Cpp/3rdParty/LLGI/src"
 )
 
+add_executable(EffekseerForWebGPUThreeJsRuntime effekseer_webgpu_runtime.cpp)
+target_link_libraries(EffekseerForWebGPUThreeJsRuntime PRIVATE TestRuntimeFramework)
+target_include_directories(
+  EffekseerForWebGPUThreeJsRuntime
+  PRIVATE
+    "${EFFEKSEER_DIR}/Dev/Cpp/TestRuntimeFramework"
+    "${EFFEKSEER_DIR}/Dev/Cpp/Effekseer"
+    "${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererCommon"
+    "${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererLLGI"
+    "${EFFEKSEER_DIR}/Dev/Cpp/EffekseerRendererWebGPU"
+    "${EFFEKSEER_DIR}/Dev/Cpp/3rdParty/LLGI/src"
+)
+
 set_target_properties(EffekseerForWebGPUThreeJsSmoke PROPERTIES SUFFIX ".html")
 target_link_options(
   EffekseerForWebGPUThreeJsSmoke
@@ -66,6 +79,22 @@ target_link_options(
     "-sASSERTIONS=1"
 )
 
+set(WEBGPU_RUNTIME_EXPORTED_FUNCTIONS "['_main','_malloc','_free','_EffekseerWebGPUCreateContext','_EffekseerWebGPUTerminate','_EffekseerWebGPULoadEffect','_EffekseerWebGPUPlayEffect','_EffekseerWebGPUStopAllEffects','_EffekseerWebGPUSetProjectionMatrix','_EffekseerWebGPUSetCameraMatrix','_EffekseerWebGPUUpdateAndCapture','_EffekseerWebGPUGetPixelsPointer','_EffekseerWebGPUGetWidth','_EffekseerWebGPUGetHeight']")
+
+set_target_properties(EffekseerForWebGPUThreeJsRuntime PROPERTIES SUFFIX ".js")
+target_link_options(
+  EffekseerForWebGPUThreeJsRuntime
+  PRIVATE
+    "-sMODULARIZE=1"
+    "-sEXPORT_NAME=effekseer_webgpu_native"
+    "-sNO_EXIT_RUNTIME=1"
+    "-sALLOW_MEMORY_GROWTH=1"
+    "-sASYNCIFY=1"
+    "-sASSERTIONS=1"
+    "SHELL:-sEXPORTED_FUNCTIONS=${WEBGPU_RUNTIME_EXPORTED_FUNCTIONS}"
+    "SHELL:-sEXPORTED_RUNTIME_METHODS=['cwrap','HEAPF32','HEAPU8']"
+)
+
 add_custom_command(
   TARGET EffekseerForWebGPUThreeJsSmoke
   POST_BUILD
@@ -73,6 +102,48 @@ add_custom_command(
     ${CMAKE_COMMAND} -E copy_if_different
     "${EFFEKSEER_FOR_WEBGL_ROOT}/docs/Sample/three.min.js"
     "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsSmoke>/three.min.js"
+)
+
+add_custom_command(
+  TARGET EffekseerForWebGPUThreeJsRuntime
+  POST_BUILD
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${EFFEKSEER_FOR_WEBGL_ROOT}/docs/Sample/three.min.js"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/three.min.js"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/effekseer.webgpu.js"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/effekseer.webgpu.js"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/threejs_webgpu_sample.html"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/threejs_webgpu_sample.html"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${EFFEKSEER_DIR}/TestData/Effects/10/SimpleLaser.efk"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/SimpleLaser.efk"
+)
+
+add_custom_target(
+  EffekseerForWebGPUThreeJsRuntimeAssets
+  DEPENDS EffekseerForWebGPUThreeJsRuntime
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${EFFEKSEER_FOR_WEBGL_ROOT}/docs/Sample/three.min.js"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/three.min.js"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/effekseer.webgpu.js"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/effekseer.webgpu.js"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/threejs_webgpu_sample.html"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/threejs_webgpu_sample.html"
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    "${EFFEKSEER_DIR}/TestData/Effects/10/SimpleLaser.efk"
+    "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/SimpleLaser.efk"
 )
 
 enable_testing()
@@ -84,5 +155,12 @@ if(NODE_EXE)
       ${NODE_EXE}
       "${CMAKE_CURRENT_SOURCE_DIR}/run_webgpu_threejs_smoke.mjs"
       "$<TARGET_FILE:EffekseerForWebGPUThreeJsSmoke>"
+  )
+  add_test(
+    NAME EffekseerForWebGPU_ThreeJsRuntimeSample
+    COMMAND
+      ${NODE_EXE}
+      "${CMAKE_CURRENT_SOURCE_DIR}/run_webgpu_threejs_smoke.mjs"
+      "$<TARGET_FILE_DIR:EffekseerForWebGPUThreeJsRuntime>/threejs_webgpu_sample.html"
   )
 endif()

--- a/webgpu/effekseer.webgpu.js
+++ b/webgpu/effekseer.webgpu.js
@@ -1,0 +1,167 @@
+const effekseerWebGPU = (() => {
+	let Module = null;
+	let Core = null;
+
+	function runtimeUrlFor(wasmUrl) {
+		return function(file) {
+			if (file.endsWith('.wasm') && wasmUrl) {
+				return wasmUrl;
+			}
+			return file;
+		};
+	}
+
+	async function requestDevice() {
+		if (!navigator.gpu) {
+			throw new Error('navigator.gpu is not available. Serve over localhost/https and use a WebGPU-capable browser.');
+		}
+
+		const adapter = await navigator.gpu.requestAdapter();
+		if (!adapter) {
+			throw new Error('Failed to request a WebGPU adapter.');
+		}
+
+		const optionalFeatures = ['float32-filterable', 'texture-formats-tier2'];
+		const requiredFeatures = optionalFeatures.filter((feature) => adapter.features && adapter.features.has(feature));
+		return adapter.requestDevice({requiredFeatures});
+	}
+
+	function bindCore() {
+		Core = {
+			CreateContext: Module.cwrap('EffekseerWebGPUCreateContext', 'number', ['number', 'number', 'number', 'number']),
+			Terminate: Module.cwrap('EffekseerWebGPUTerminate', 'void', ['number']),
+			LoadEffect: Module.cwrap('EffekseerWebGPULoadEffect', 'number', ['number', 'number', 'number', 'number']),
+			PlayEffect: Module.cwrap('EffekseerWebGPUPlayEffect', 'number', ['number', 'number', 'number', 'number', 'number']),
+			StopAllEffects: Module.cwrap('EffekseerWebGPUStopAllEffects', 'void', ['number']),
+			SetProjectionMatrix: Module.cwrap('EffekseerWebGPUSetProjectionMatrix', 'void', ['number', 'number']),
+			SetCameraMatrix: Module.cwrap('EffekseerWebGPUSetCameraMatrix', 'void', ['number', 'number']),
+			UpdateAndCapture: Module.cwrap('EffekseerWebGPUUpdateAndCapture', 'number', ['number', 'number'], {async: true}),
+			GetPixelsPointer: Module.cwrap('EffekseerWebGPUGetPixelsPointer', 'number', ['number']),
+			GetWidth: Module.cwrap('EffekseerWebGPUGetWidth', 'number', ['number']),
+			GetHeight: Module.cwrap('EffekseerWebGPUGetHeight', 'number', ['number']),
+		};
+	}
+
+	function copyMatrixToWasm(elements, pointer) {
+		Module.HEAPF32.set(elements, pointer >> 2);
+	}
+
+	class Effect {
+		constructor(context, id) {
+			this.context = context;
+			this.id = id;
+		}
+	}
+
+	class Context {
+		constructor(options) {
+			const width = options && options.width ? options.width : 320;
+			const height = options && options.height ? options.height : 240;
+			const instanceMaxCount = options && options.instanceMaxCount ? options.instanceMaxCount : 8000;
+			const spriteMaxCount = options && options.spriteMaxCount ? options.spriteMaxCount : 2000;
+
+			this.nativeptr = Core.CreateContext(width, height, instanceMaxCount, spriteMaxCount);
+			if (!this.nativeptr) {
+				throw new Error('Failed to create Effekseer WebGPU context.');
+			}
+
+			this.width = Core.GetWidth(this.nativeptr);
+			this.height = Core.GetHeight(this.nativeptr);
+			this.matrixPointer = Module._malloc(16 * 4);
+			this.imageData = new ImageData(this.width, this.height);
+		}
+
+		terminate() {
+			if (this.matrixPointer) {
+				Module._free(this.matrixPointer);
+				this.matrixPointer = 0;
+			}
+			if (this.nativeptr) {
+				Core.Terminate(this.nativeptr);
+				this.nativeptr = 0;
+			}
+		}
+
+		async loadEffect(url, magnification = 1.0) {
+			const response = await fetch(url);
+			if (!response.ok) {
+				throw new Error(`Failed to load effect: ${response.status} ${url}`);
+			}
+
+			const buffer = await response.arrayBuffer();
+			const pointer = Module._malloc(buffer.byteLength);
+			try {
+				Module.HEAPU8.set(new Uint8Array(buffer), pointer);
+				const id = Core.LoadEffect(this.nativeptr, pointer, buffer.byteLength, magnification);
+				if (!id) {
+					throw new Error(`Effekseer failed to create effect: ${url}`);
+				}
+				return new Effect(this, id);
+			} finally {
+				Module._free(pointer);
+			}
+		}
+
+		play(effect, x = 0, y = 0, z = 0) {
+			return Core.PlayEffect(this.nativeptr, effect.id, x, y, z);
+		}
+
+		stopAll() {
+			Core.StopAllEffects(this.nativeptr);
+		}
+
+		setProjectionMatrix(elements) {
+			copyMatrixToWasm(elements, this.matrixPointer);
+			Core.SetProjectionMatrix(this.nativeptr, this.matrixPointer);
+		}
+
+		setCameraMatrix(elements) {
+			copyMatrixToWasm(elements, this.matrixPointer);
+			Core.SetCameraMatrix(this.nativeptr, this.matrixPointer);
+		}
+
+		async draw(camera, deltaFrames = 1) {
+			if (camera) {
+				this.setProjectionMatrix(camera.projectionMatrix.elements);
+				this.setCameraMatrix(camera.matrixWorldInverse.elements);
+			}
+
+			const byteLength = await Core.UpdateAndCapture(this.nativeptr, deltaFrames);
+			const pixelsPointer = Core.GetPixelsPointer(this.nativeptr);
+			if (!byteLength || !pixelsPointer) {
+				throw new Error('Effekseer WebGPU frame capture failed.');
+			}
+
+			this.imageData.data.set(Module.HEAPU8.subarray(pixelsPointer, pixelsPointer + byteLength));
+			return this.imageData;
+		}
+
+		async drawToCanvas(canvas, camera, deltaFrames = 1) {
+			const imageData = await this.draw(camera, deltaFrames);
+			canvas.getContext('2d').putImageData(imageData, 0, 0);
+			return imageData;
+		}
+	}
+
+	async function initRuntime(options = {}) {
+		const device = options.device || await requestDevice();
+		Module = await effekseer_webgpu_native({
+			locateFile: runtimeUrlFor(options.wasmUrl),
+			preinitializedWebGPUDevice: device,
+		});
+		bindCore();
+
+		return {
+			createContext(contextOptions) {
+				return new Context(contextOptions);
+			},
+			device,
+		};
+	}
+
+	return {
+		initRuntime,
+	};
+})();
+
+globalThis.effekseerWebGPU = effekseerWebGPU;

--- a/webgpu/effekseer_webgpu_runtime.cpp
+++ b/webgpu/effekseer_webgpu_runtime.cpp
@@ -1,0 +1,191 @@
+#if !defined(__EMSCRIPTEN__)
+#error This runtime is browser-only and requires Emscripten.
+#endif
+
+#include "webgpu_offscreen_platform.h"
+
+#include <Effekseer.h>
+#include <emscripten.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace
+{
+
+using EffekseerWebGPU::EffectPlatformWebGPUOffscreen;
+
+void ArrayToMatrix44(const float* array, Effekseer::Matrix44& matrix)
+{
+	for (int row = 0; row < 4; row++)
+	{
+		for (int column = 0; column < 4; column++)
+		{
+			matrix.Values[row][column] = array[row * 4 + column];
+		}
+	}
+}
+
+struct RuntimeContext
+{
+	std::shared_ptr<EffectPlatformWebGPUOffscreen> platform;
+	std::vector<Effekseer::EffectRef> effects;
+	std::vector<uint8_t> pixels;
+	int32_t width = 320;
+	int32_t height = 240;
+};
+
+RuntimeContext* ToContext(uintptr_t value)
+{
+	return reinterpret_cast<RuntimeContext*>(value);
+}
+
+} // namespace
+
+#define EXPORT EMSCRIPTEN_KEEPALIVE
+
+extern "C"
+{
+	uintptr_t EXPORT EffekseerWebGPUCreateContext(int32_t width, int32_t height, int32_t instanceMaxCount, int32_t spriteMaxCount)
+	{
+		auto context = std::make_unique<RuntimeContext>();
+		context->width = std::max(1, width);
+		context->height = std::max(1, height);
+
+		EffectPlatformInitializingParameter param;
+		param.VSync = false;
+		param.WindowSize = {context->width, context->height};
+		param.InstanceCount = instanceMaxCount > 0 ? instanceMaxCount : 8000;
+		param.SpriteCount = spriteMaxCount > 0 ? spriteMaxCount : 2000;
+		param.BackgroundPattern = BackgroundPatternType::NonPeriodicGradient;
+
+		context->platform = std::make_shared<EffectPlatformWebGPUOffscreen>();
+		context->platform->Initialize(param);
+		return reinterpret_cast<uintptr_t>(context.release());
+	}
+
+	void EXPORT EffekseerWebGPUTerminate(uintptr_t contextValue)
+	{
+		auto context = ToContext(contextValue);
+		if (context == nullptr)
+		{
+			return;
+		}
+		context->platform->Terminate();
+		delete context;
+	}
+
+	int32_t EXPORT EffekseerWebGPULoadEffect(uintptr_t contextValue, const void* data, int32_t size, float magnification)
+	{
+		auto context = ToContext(contextValue);
+		if (context == nullptr || data == nullptr || size <= 0)
+		{
+			return 0;
+		}
+
+		auto effect = Effekseer::Effect::Create(context->platform->GetManager(), const_cast<void*>(data), size, magnification);
+		if (effect == nullptr)
+		{
+			return 0;
+		}
+
+		context->effects.push_back(effect);
+		return static_cast<int32_t>(context->effects.size());
+	}
+
+	int32_t EXPORT EffekseerWebGPUPlayEffect(uintptr_t contextValue, int32_t effectId, float x, float y, float z)
+	{
+		auto context = ToContext(contextValue);
+		if (context == nullptr || effectId <= 0 || effectId > static_cast<int32_t>(context->effects.size()))
+		{
+			return -1;
+		}
+
+		return context->platform->GetManager()->Play(context->effects[effectId - 1], x, y, z);
+	}
+
+	void EXPORT EffekseerWebGPUStopAllEffects(uintptr_t contextValue)
+	{
+		auto context = ToContext(contextValue);
+		if (context != nullptr)
+		{
+			context->platform->StopAllEffects();
+		}
+	}
+
+	void EXPORT EffekseerWebGPUSetProjectionMatrix(uintptr_t contextValue, const float* matrixElements)
+	{
+		auto context = ToContext(contextValue);
+		if (context == nullptr || matrixElements == nullptr)
+		{
+			return;
+		}
+
+		Effekseer::Matrix44 matrix;
+		ArrayToMatrix44(matrixElements, matrix);
+		context->platform->GetRenderer()->SetProjectionMatrix(matrix);
+	}
+
+	void EXPORT EffekseerWebGPUSetCameraMatrix(uintptr_t contextValue, const float* matrixElements)
+	{
+		auto context = ToContext(contextValue);
+		if (context == nullptr || matrixElements == nullptr)
+		{
+			return;
+		}
+
+		Effekseer::Matrix44 matrix;
+		ArrayToMatrix44(matrixElements, matrix);
+		context->platform->GetRenderer()->SetCameraMatrix(matrix);
+	}
+
+	int32_t EXPORT EffekseerWebGPUUpdateAndCapture(uintptr_t contextValue, float deltaFrames)
+	{
+		auto context = ToContext(contextValue);
+		if (context == nullptr)
+		{
+			return 0;
+		}
+
+		const auto wholeFrames = std::max(1, static_cast<int32_t>(std::ceil(deltaFrames)));
+		for (int32_t frame = 0; frame < wholeFrames; frame++)
+		{
+			if (!context->platform->Update())
+			{
+				return 0;
+			}
+		}
+
+		context->pixels = context->platform->CaptureOffscreenPixels();
+		return static_cast<int32_t>(context->pixels.size());
+	}
+
+	uintptr_t EXPORT EffekseerWebGPUGetPixelsPointer(uintptr_t contextValue)
+	{
+		auto context = ToContext(contextValue);
+		if (context == nullptr || context->pixels.empty())
+		{
+			return 0;
+		}
+		return reinterpret_cast<uintptr_t>(context->pixels.data());
+	}
+
+	int32_t EXPORT EffekseerWebGPUGetWidth(uintptr_t contextValue)
+	{
+		auto context = ToContext(contextValue);
+		return context != nullptr ? context->width : 0;
+	}
+
+	int32_t EXPORT EffekseerWebGPUGetHeight(uintptr_t contextValue)
+	{
+		auto context = ToContext(contextValue);
+		return context != nullptr ? context->height : 0;
+	}
+}
+
+int main(int, char**) { return 0; }

--- a/webgpu/pre_effekseer_webgpu_threejs_smoke.js
+++ b/webgpu/pre_effekseer_webgpu_threejs_smoke.js
@@ -1,0 +1,151 @@
+if (typeof Module === 'undefined') {
+	var Module = {};
+}
+
+Module.__effekseerWebGPUTestResult = Module.effekseerWebGPUTestResult || null;
+Object.defineProperty(Module, 'effekseerWebGPUTestResult', {
+	configurable: true,
+	get: function() {
+		return Module.__effekseerWebGPUTestResult;
+	},
+	set: function(value) {
+		Module.__effekseerWebGPUTestResult = value;
+		if (typeof document !== 'undefined' && value) {
+			document.documentElement.setAttribute('data-effekseer-webgpu-test-status', value.status || '');
+			document.documentElement.setAttribute('data-effekseer-webgpu-test-message', value.message || '');
+		}
+	}
+});
+
+function effekseerGetWebGPUThreeJsParams() {
+	var params = typeof URLSearchParams !== 'undefined' && typeof location !== 'undefined'
+		? new URLSearchParams(location.search)
+		: null;
+	var get = function(name, fallback) {
+		return params && params.get(name) ? params.get(name) : fallback;
+	};
+
+	return {
+		effect: get('effect', '/TestData/Effects/10/SimpleLaser.efk'),
+		width: get('width', '320'),
+		height: get('height', '240'),
+		frames: get('frames', '36'),
+		minChangedPixels: get('minChangedPixels', '100')
+	};
+}
+
+var effekseerWebGPUThreeJsParams = effekseerGetWebGPUThreeJsParams();
+
+Module.arguments = Module.arguments || [
+	'--effect=' + effekseerWebGPUThreeJsParams.effect,
+	'--width=' + effekseerWebGPUThreeJsParams.width,
+	'--height=' + effekseerWebGPUThreeJsParams.height,
+	'--frames=' + effekseerWebGPUThreeJsParams.frames,
+	'--min-changed-pixels=' + effekseerWebGPUThreeJsParams.minChangedPixels
+];
+
+function effekseerLoadScript(src) {
+	return new Promise(function(resolve, reject) {
+		var script = document.createElement('script');
+		script.src = src;
+		script.onload = resolve;
+		script.onerror = function() {
+			reject(new Error('Failed to load ' + src));
+		};
+		document.head.appendChild(script);
+	});
+}
+
+function effekseerPrepareThreeJsCamera() {
+	var width = Number(effekseerWebGPUThreeJsParams.width) || 320;
+	var height = Number(effekseerWebGPUThreeJsParams.height) || 240;
+
+	var camera = new THREE.PerspectiveCamera(30.0, width / height, 1.0, 1000.0);
+	camera.position.set(20, 20, 20);
+	camera.lookAt(new THREE.Vector3(0, 0, 0));
+	camera.updateMatrixWorld(true);
+
+	Module.effekseerThreeJsProjectionMatrix = Array.prototype.slice.call(camera.projectionMatrix.elements);
+	Module.effekseerThreeJsCameraMatrix = Array.prototype.slice.call(camera.matrixWorldInverse.elements);
+	Module.effekseerThreeJsCameraDescription = {
+		fov: camera.fov,
+		aspect: camera.aspect,
+		near: camera.near,
+		far: camera.far
+	};
+
+	console.log(
+		'EFFEKSEER_THREEJS_CAMERA_READY fov=' + camera.fov +
+		' aspect=' + camera.aspect +
+		' near=' + camera.near +
+		' far=' + camera.far
+	);
+}
+
+function effekseerPrepareCanvas() {
+	var canvas = Module.canvas || (typeof document !== 'undefined' ? document.getElementById('canvas') : null);
+	if (!canvas) {
+		return;
+	}
+
+	var width = Number(effekseerWebGPUThreeJsParams.width) || 320;
+	var height = Number(effekseerWebGPUThreeJsParams.height) || 240;
+	canvas.width = width;
+	canvas.height = height;
+	canvas.style.width = width + 'px';
+	canvas.style.height = height + 'px';
+}
+
+async function effekseerRequestWebGPUDevice() {
+	if (!navigator.gpu) {
+		throw new Error('navigator.gpu is not available. Serve over localhost/https and use a WebGPU-capable browser.');
+	}
+
+	var adapter = await navigator.gpu.requestAdapter();
+	if (!adapter) {
+		throw new Error('Failed to request a WebGPU adapter.');
+	}
+
+	var optionalFeatures = ['float32-filterable', 'texture-formats-tier2'];
+	var requiredFeatures = optionalFeatures.filter(function(feature) {
+		return adapter.features && adapter.features.has(feature);
+	});
+
+	Module.preinitializedWebGPUDevice = await adapter.requestDevice({
+		requiredFeatures: requiredFeatures
+	});
+	Module.preinitializedWebGPUDevice.addEventListener('uncapturederror', function(event) {
+		Module.llgiLastWebGPUError = event.error && event.error.message ? event.error.message : String(event.error);
+		console.error('EFFEKSEER_WEBGPU_ERROR', Module.llgiLastWebGPUError);
+	});
+}
+
+Module.preRun = Module.preRun || [];
+Module.preRun.push(function() {
+	effekseerPrepareCanvas();
+
+	var dependency = 'effekseer-webgpu-threejs-smoke';
+	addRunDependency(dependency);
+
+	Promise.all([
+		effekseerLoadScript('three.min.js').then(effekseerPrepareThreeJsCamera),
+		effekseerRequestWebGPUDevice()
+	]).then(function() {
+		removeRunDependency(dependency);
+	}).catch(function(error) {
+		Module.effekseerWebGPUTestResult = {
+			status: 'failed',
+			message: error && error.message ? error.message : String(error)
+		};
+		console.error('EFFEKSEER_TEST_FAIL', Module.effekseerWebGPUTestResult.message);
+		removeRunDependency(dependency);
+	});
+});
+
+Module.onAbort = function(reason) {
+	Module.effekseerWebGPUTestResult = {
+		status: 'failed',
+		message: reason ? String(reason) : 'aborted'
+	};
+	console.error('EFFEKSEER_TEST_FAIL', Module.effekseerWebGPUTestResult.message);
+};

--- a/webgpu/run_webgpu_threejs_smoke.mjs
+++ b/webgpu/run_webgpu_threejs_smoke.mjs
@@ -76,11 +76,11 @@ try {
 	if (result.status !== 'passed') {
 		throw new Error(result.message || 'Effekseer WebGPU Three.js smoke failed.');
 	}
-	console.log(`EFFEKSEER_WEBGPU_THREEJS_SMOKE_PASS ${result.message || ''}`.trim());
+	console.log(`EFFEKSEER_WEBGPU_THREEJS_RUNNER_PASS ${result.message || ''}`.trim());
 } finally {
 	await stopBrowser(browser);
 	server.close();
-	fs.rmSync(userDataDir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100});
+	await removeDirectory(userDataDir);
 }
 
 function parseOptions(optionArgs) {
@@ -287,7 +287,7 @@ async function waitForResult(cdp, browser, getStderr) {
 		}
 
 		const response = await cdp.send('Runtime.evaluate', {
-			expression: 'globalThis.Module && Module.effekseerWebGPUTestResult ? Module.effekseerWebGPUTestResult : null',
+			expression: '(globalThis.Module && Module.effekseerWebGPUTestResult) || globalThis.effekseerWebGPURuntimeSampleResult || null',
 			returnByValue: true,
 			awaitPromise: false,
 		});
@@ -298,7 +298,7 @@ async function waitForResult(cdp, browser, getStderr) {
 
 		await delay(250);
 	}
-	throw new Error('Timed out waiting for Effekseer WebGPU Three.js smoke result.');
+	throw new Error('Timed out waiting for Effekseer WebGPU Three.js browser result.');
 }
 
 async function captureScreenshot(cdp, screenshotPath) {
@@ -321,4 +321,19 @@ async function stopBrowser(browser) {
 		new Promise((resolve) => browser.once('exit', resolve)),
 		delay(3000),
 	]);
+}
+
+async function removeDirectory(directory) {
+	for (let attempt = 0; attempt < 20; attempt++) {
+		try {
+			fs.rmSync(directory, {recursive: true, force: true});
+			return;
+		} catch (error) {
+			if (attempt === 19) {
+				console.warn(`Failed to remove temporary browser profile ${directory}: ${error.message}`);
+				return;
+			}
+			await delay(100);
+		}
+	}
 }

--- a/webgpu/run_webgpu_threejs_smoke.mjs
+++ b/webgpu/run_webgpu_threejs_smoke.mjs
@@ -1,0 +1,324 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {spawn} from 'node:child_process';
+
+const args = process.argv.slice(2);
+const htmlPath = args[0];
+const optionArgs = args.slice(1);
+
+if (!htmlPath) {
+	console.error('Usage: node webgpu/run_webgpu_threejs_smoke.mjs <EffekseerForWebGPUThreeJsSmoke.html> [--screenshot=path] [--width=320] [--height=240]');
+	process.exit(2);
+}
+
+const resolvedHtmlPath = path.resolve(htmlPath);
+if (!fs.existsSync(resolvedHtmlPath)) {
+	console.error(`Not found: ${resolvedHtmlPath}`);
+	process.exit(2);
+}
+
+const options = parseOptions(optionArgs);
+const root = path.dirname(resolvedHtmlPath);
+const htmlFile = path.basename(resolvedHtmlPath);
+const executablePath = findBrowserExecutable();
+const server = await createServer(root, htmlFile);
+const {port} = server.address();
+const devtoolsPort = await getFreePort();
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'effekseer-webgpu-threejs-'));
+const url = `http://127.0.0.1:${port}/${htmlFile}?${options.query.toString()}`;
+
+let browser;
+
+try {
+	browser = spawn(executablePath, [
+		`--user-data-dir=${userDataDir}`,
+		`--remote-debugging-port=${devtoolsPort}`,
+		'--no-first-run',
+		'--no-default-browser-check',
+		'--enable-unsafe-webgpu',
+		'--ignore-gpu-blocklist',
+		...chromeGpuArgs(),
+		...(process.env.EFFEKSEER_WEBGPU_HEADLESS === '0' ? [] : ['--headless=new']),
+		url,
+	], {stdio: ['ignore', 'pipe', 'pipe']});
+
+	let browserStderr = '';
+	browser.stderr.on('data', (chunk) => {
+		browserStderr += chunk.toString();
+		process.stderr.write(chunk);
+	});
+	browser.stdout.on('data', (chunk) => process.stdout.write(chunk));
+
+	await waitForDevTools(devtoolsPort, browser, () => browserStderr);
+	const page = await findPage(devtoolsPort, url);
+	const cdp = await connectCDP(page.webSocketDebuggerUrl);
+
+	await cdp.send('Runtime.enable');
+	await cdp.send('Page.enable');
+	cdp.on('Runtime.consoleAPICalled', (params) => {
+		const text = params.args.map((arg) => arg.value ?? arg.description ?? '').join(' ');
+		if (text) {
+			console.log(`[browser:${params.type}] ${text}`);
+		}
+	});
+	cdp.on('Runtime.exceptionThrown', (params) => {
+		console.error('[browser:exception]', params.exceptionDetails?.text || 'exception');
+	});
+
+	const result = await waitForResult(cdp, browser, () => browserStderr);
+	if (options.screenshot) {
+		await captureScreenshot(cdp, options.screenshot);
+	}
+
+	await cdp.close();
+	if (result.status !== 'passed') {
+		throw new Error(result.message || 'Effekseer WebGPU Three.js smoke failed.');
+	}
+	console.log(`EFFEKSEER_WEBGPU_THREEJS_SMOKE_PASS ${result.message || ''}`.trim());
+} finally {
+	await stopBrowser(browser);
+	server.close();
+	fs.rmSync(userDataDir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100});
+}
+
+function parseOptions(optionArgs) {
+	const query = new URLSearchParams();
+	let screenshot = null;
+	for (const option of optionArgs) {
+		if (!option.startsWith('--')) {
+			continue;
+		}
+		const separator = option.indexOf('=');
+		const key = separator > 2 ? option.substring(2, separator) : option.substring(2);
+		const value = separator > 2 ? option.substring(separator + 1) : '1';
+		if (key === 'screenshot') {
+			screenshot = value;
+		} else {
+			query.set(key, value);
+		}
+	}
+	return {query, screenshot};
+}
+
+function findBrowserExecutable() {
+	const candidates = [
+		process.env.CHROME_PATH,
+		process.env.EDGE_PATH,
+		'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+		'/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+		'/usr/bin/google-chrome',
+		'/usr/bin/google-chrome-stable',
+		'/usr/bin/chromium',
+		'/usr/bin/chromium-browser',
+		'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+		'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+		'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+		'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+	].filter(Boolean);
+
+	for (const candidate of candidates) {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	console.error('A WebGPU-capable Chrome or Edge executable is required.');
+	console.error('Set CHROME_PATH or EDGE_PATH if it is installed in a custom location.');
+	process.exit(2);
+}
+
+function chromeGpuArgs() {
+	if (process.platform === 'win32') {
+		return ['--use-angle=d3d11'];
+	}
+	if (process.platform === 'darwin') {
+		return ['--use-angle=metal'];
+	}
+	return [];
+}
+
+function contentType(filePath) {
+	if (filePath.endsWith('.html')) return 'text/html';
+	if (filePath.endsWith('.js')) return 'application/javascript';
+	if (filePath.endsWith('.wasm')) return 'application/wasm';
+	if (filePath.endsWith('.data')) return 'application/octet-stream';
+	if (filePath.endsWith('.png')) return 'image/png';
+	return 'application/octet-stream';
+}
+
+async function createServer(root, htmlFile) {
+	const server = http.createServer((request, response) => {
+		const requestUrl = new URL(request.url, 'http://127.0.0.1');
+		if (requestUrl.pathname === '/favicon.ico') {
+			response.writeHead(204);
+			response.end();
+			return;
+		}
+
+		const relativePath = decodeURIComponent(requestUrl.pathname === '/' ? `/${htmlFile}` : requestUrl.pathname);
+		const filePath = path.resolve(root, `.${relativePath}`);
+		const relativeFromRoot = path.relative(root, filePath);
+
+		if (relativeFromRoot.startsWith('..') || path.isAbsolute(relativeFromRoot) || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+			response.writeHead(404);
+			response.end('Not found');
+			return;
+		}
+
+		response.writeHead(200, {
+			'Content-Type': contentType(filePath),
+			'Cache-Control': 'no-store, max-age=0',
+			'Pragma': 'no-cache',
+			'Expires': '0',
+		});
+		fs.createReadStream(filePath).pipe(response);
+	});
+
+	await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+	return server;
+}
+
+async function getFreePort() {
+	const probe = http.createServer();
+	await new Promise((resolve) => probe.listen(0, '127.0.0.1', resolve));
+	const freePort = probe.address().port;
+	await new Promise((resolve) => probe.close(resolve));
+	return freePort;
+}
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForDevTools(devtoolsPort, browser, getStderr) {
+	const start = Date.now();
+	while (Date.now() - start < 30000) {
+		if (browser.exitCode !== null) {
+			throw new Error(`Chrome exited before DevTools was ready.${getStderr() ? `\n${getStderr()}` : ''}`);
+		}
+		try {
+			const response = await fetch(`http://127.0.0.1:${devtoolsPort}/json/version`);
+			if (response.ok) {
+				return;
+			}
+		} catch {
+		}
+		await delay(100);
+	}
+	throw new Error('Timed out waiting for Chrome DevTools HTTP endpoint.');
+}
+
+async function findPage(devtoolsPort, pageUrl) {
+	const start = Date.now();
+	while (Date.now() - start < 10000) {
+		const response = await fetch(`http://127.0.0.1:${devtoolsPort}/json`);
+		if (response.ok) {
+			const pages = await response.json();
+			const page = pages.find((entry) => entry.type === 'page' && entry.url === pageUrl) ||
+				pages.find((entry) => entry.type === 'page' && entry.webSocketDebuggerUrl);
+			if (page?.webSocketDebuggerUrl) {
+				return page;
+			}
+		}
+		await delay(100);
+	}
+	throw new Error('Timed out finding Chrome page.');
+}
+
+async function connectCDP(webSocketDebuggerUrl) {
+	const socket = new WebSocket(webSocketDebuggerUrl);
+	const pending = new Map();
+	const listeners = new Map();
+	let id = 0;
+
+	socket.addEventListener('message', (event) => {
+		const message = JSON.parse(event.data);
+		if (message.id && pending.has(message.id)) {
+			const {resolve, reject} = pending.get(message.id);
+			pending.delete(message.id);
+			if (message.error) {
+				reject(new Error(message.error.message || JSON.stringify(message.error)));
+			} else {
+				resolve(message.result || {});
+			}
+			return;
+		}
+
+		const callbacks = listeners.get(message.method);
+		if (callbacks) {
+			for (const callback of callbacks) {
+				callback(message.params || {});
+			}
+		}
+	});
+
+	await new Promise((resolve, reject) => {
+		socket.addEventListener('open', resolve, {once: true});
+		socket.addEventListener('error', reject, {once: true});
+	});
+
+	return {
+		send(method, params = {}) {
+			const messageId = ++id;
+			socket.send(JSON.stringify({id: messageId, method, params}));
+			return new Promise((resolve, reject) => {
+				pending.set(messageId, {resolve, reject});
+			});
+		},
+		on(method, callback) {
+			if (!listeners.has(method)) {
+				listeners.set(method, []);
+			}
+			listeners.get(method).push(callback);
+		},
+		close() {
+			socket.close();
+		}
+	};
+}
+
+async function waitForResult(cdp, browser, getStderr) {
+	const start = Date.now();
+	while (Date.now() - start < 60000) {
+		if (browser.exitCode !== null) {
+			throw new Error(`Chrome exited before the smoke completed.${getStderr() ? `\n${getStderr()}` : ''}`);
+		}
+
+		const response = await cdp.send('Runtime.evaluate', {
+			expression: 'globalThis.Module && Module.effekseerWebGPUTestResult ? Module.effekseerWebGPUTestResult : null',
+			returnByValue: true,
+			awaitPromise: false,
+		});
+		const result = response.result?.value;
+		if (result?.status) {
+			return result;
+		}
+
+		await delay(250);
+	}
+	throw new Error('Timed out waiting for Effekseer WebGPU Three.js smoke result.');
+}
+
+async function captureScreenshot(cdp, screenshotPath) {
+	const response = await cdp.send('Page.captureScreenshot', {format: 'png', fromSurface: true});
+	if (!response.data) {
+		throw new Error('Chrome did not return screenshot data.');
+	}
+	fs.mkdirSync(path.dirname(path.resolve(screenshotPath)), {recursive: true});
+	fs.writeFileSync(screenshotPath, Buffer.from(response.data, 'base64'));
+	console.log(`Wrote screenshot: ${screenshotPath}`);
+}
+
+async function stopBrowser(browser) {
+	if (!browser || browser.exitCode !== null) {
+		return;
+	}
+
+	browser.kill();
+	await Promise.race([
+		new Promise((resolve) => browser.once('exit', resolve)),
+		delay(3000),
+	]);
+}

--- a/webgpu/threejs_smoke.cpp
+++ b/webgpu/threejs_smoke.cpp
@@ -1,0 +1,480 @@
+#if !defined(__EMSCRIPTEN__)
+#error This smoke test is browser-only and requires Emscripten.
+#endif
+
+#include <Runtime/EffectPlatformLLGI.h>
+#include <Effekseer.h>
+#include <EffekseerRendererLLGI/EffekseerRendererLLGI.Renderer.h>
+#include <EffekseerRendererLLGI/GraphicsDevice.h>
+#include <EffekseerRendererWebGPU.h>
+#include <emscripten.h>
+#include <LLGI.CommandList.h>
+#include <LLGI.Graphics.h>
+#include <LLGI.Texture.h>
+#include <WebGPU/LLGI.CompilerWebGPU.h>
+#include <WebGPU/LLGI.PlatformWebGPU.h>
+
+#include <array>
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+struct SmokeOptions
+{
+	std::string EffectPath = "/TestData/Effects/10/SimpleLaser.efk";
+	int32_t Width = 320;
+	int32_t Height = 240;
+	int32_t Frames = 36;
+	size_t MinimumChangedPixels = 100;
+};
+
+const char* OffscreenCopyVertexShaderWGSL = R"(
+struct VSInput {
+    @location(0) position: vec3<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) color: vec4<f32>,
+};
+
+struct VSOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+@vertex
+fn main(input: VSInput) -> VSOutput {
+    var output: VSOutput;
+    output.position = vec4<f32>(input.position, 1.0);
+    output.uv = input.uv;
+    output.color = input.color;
+    return output;
+}
+)";
+
+const char* OffscreenCopyPixelShaderWGSL = R"(
+@group(1) @binding(0) var colorTexture: texture_2d<f32>;
+@group(2) @binding(0) var colorSampler: sampler;
+
+struct PSInput {
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+@fragment
+fn main(input: PSInput) -> @location(0) vec4<f32> {
+    return textureSample(colorTexture, colorSampler, input.uv);
+}
+)";
+
+class EffectPlatformWebGPUOffscreen;
+
+class DistortingCallbackWebGPUOffscreen : public EffekseerRenderer::DistortingCallback
+{
+	EffectPlatformWebGPUOffscreen* platform_ = nullptr;
+	Effekseer::Backend::TextureRef texture_ = nullptr;
+
+public:
+	explicit DistortingCallbackWebGPUOffscreen(EffectPlatformWebGPUOffscreen* platform)
+		: platform_(platform)
+	{
+	}
+
+	~DistortingCallbackWebGPUOffscreen() override { texture_.Reset(); }
+
+	bool OnDistorting(EffekseerRenderer::Renderer* renderer) override;
+};
+
+class EffectPlatformWebGPUOffscreen final : public EffectPlatformLLGI
+{
+	LLGI::Texture* backgroundTexture_ = nullptr;
+
+	void InitializeWindow() override
+	{
+		auto device = wgpu::Device::Acquire(emscripten_webgpu_get_device());
+		if (device == nullptr)
+		{
+			throw std::runtime_error("Failed to get preinitialized browser WebGPU device.");
+		}
+
+		auto platform = new LLGI::PlatformWebGPU();
+		if (!platform->Initialize(device, initParam_.VSync))
+		{
+			LLGI::SafeRelease(platform);
+			throw std::runtime_error("Failed to initialize offscreen LLGI WebGPU platform.");
+		}
+
+		platform_ = platform;
+		graphics_ = platform_->CreateGraphics();
+		if (graphics_ == nullptr)
+		{
+			throw std::runtime_error("Failed to create LLGI WebGPU graphics.");
+		}
+
+		sfMemoryPool_ = graphics_->CreateSingleFrameMemoryPool(1024 * 1024, 128);
+		commandListPool_ = std::make_shared<LLGI::CommandListPool>(graphics_, sfMemoryPool_, 3);
+	}
+
+	void CreateShaders() override
+	{
+		auto compiler = new LLGI::CompilerWebGPU();
+		compiler->Initialize();
+
+		LLGI::CompilerResult resultVS;
+		LLGI::CompilerResult resultPS;
+		compiler->Compile(resultVS, OffscreenCopyVertexShaderWGSL, LLGI::ShaderStageType::Vertex);
+		compiler->Compile(resultPS, OffscreenCopyPixelShaderWGSL, LLGI::ShaderStageType::Pixel);
+		assert(resultVS.Message == "");
+		assert(resultPS.Message == "");
+		compiler->Release();
+
+		std::vector<LLGI::DataStructure> dataVS;
+		std::vector<LLGI::DataStructure> dataPS;
+		for (auto& binary : resultVS.Binary)
+		{
+			LLGI::DataStructure data;
+			data.Data = binary.data();
+			data.Size = static_cast<int32_t>(binary.size());
+			dataVS.push_back(data);
+		}
+		for (auto& binary : resultPS.Binary)
+		{
+			LLGI::DataStructure data;
+			data.Data = binary.data();
+			data.Size = static_cast<int32_t>(binary.size());
+			dataPS.push_back(data);
+		}
+
+		shader_vs_ = graphics_->CreateShader(dataVS.data(), static_cast<int32_t>(dataVS.size()));
+		shader_ps_ = graphics_->CreateShader(dataPS.data(), static_cast<int32_t>(dataPS.size()));
+	}
+
+	EffekseerRenderer::RendererRef CreateRenderer() override
+	{
+		::EffekseerRendererWebGPU::RenderPassInformation renderPassInfo;
+		renderPassInfo.DoesPresentToScreen = false;
+		renderPassInfo.RenderTextureCount = 1;
+		renderPassInfo.RenderTextureFormats[0] = wgpu::TextureFormat::RGBA8Unorm;
+		renderPassInfo.DepthFormat = wgpu::TextureFormat::Depth32Float;
+
+		auto graphicsDevice = Effekseer::MakeRefPtr<EffekseerRendererLLGI::Backend::GraphicsDevice>(graphics_);
+		auto renderer = ::EffekseerRendererWebGPU::Create(graphicsDevice, renderPassInfo, initParam_.SpriteCount);
+		renderer->SetDistortingCallback(new DistortingCallbackWebGPUOffscreen(this));
+
+		sfMemoryPoolEfk_ = EffekseerRenderer::CreateSingleFrameMemoryPool(renderer->GetGraphicsDevice());
+		CreateResources();
+		return renderer;
+	}
+
+	void InitializeDevice(const EffectPlatformInitializingParameter&) override { CreateCheckedTexture(); }
+
+	void DestroyDevice() override
+	{
+		ES_SAFE_RELEASE(backgroundTexture_);
+		EffectPlatformLLGI::DestroyDevice();
+	}
+
+	void BeginRendering() override
+	{
+		EffectPlatformLLGI::BeginRendering();
+
+		auto memoryPool = static_cast<EffekseerRendererLLGI::SingleFrameMemoryPool*>(sfMemoryPoolEfk_.Get());
+		commandListEfk_ = Effekseer::MakeRefPtr<EffekseerRendererLLGI::CommandList>(graphics_, commandList_.get(), memoryPool->GetInternal());
+		GetRenderer()->SetCommandList(commandListEfk_);
+	}
+
+	void EndRendering() override
+	{
+		GetRenderer()->SetCommandList(nullptr);
+		commandListEfk_.Reset();
+		commandList_->EndRenderPass();
+		commandList_->End();
+	}
+
+public:
+	EffectPlatformWebGPUOffscreen()
+		: EffectPlatformLLGI(LLGI::DeviceType::WebGPU)
+	{
+	}
+
+	~EffectPlatformWebGPUOffscreen() override = default;
+
+	std::vector<uint8_t> CaptureOffscreenPixels()
+	{
+		if (commandList_ != nullptr)
+		{
+			commandList_->WaitUntilCompleted();
+		}
+		if (graphics_ == nullptr || colorBuffer_ == nullptr)
+		{
+			return {};
+		}
+		return graphics_->CaptureRenderTarget(colorBuffer_);
+	}
+
+	LLGI::Texture* GetBackgroundTexture()
+	{
+		if (backgroundTexture_ == nullptr)
+		{
+			LLGI::TextureParameter param;
+			param.Size = LLGI::Vec3I(initParam_.WindowSize[0], initParam_.WindowSize[1], 1);
+			backgroundTexture_ = graphics_->CreateTexture(param);
+		}
+		return backgroundTexture_;
+	}
+
+	void UpdateBackgroundTextureForDistortion()
+	{
+		auto background = GetBackgroundTexture();
+
+		commandList_->EndRenderPass();
+		commandList_->CopyTexture(colorBuffer_, background);
+
+		renderPass_->SetIsColorCleared(false);
+		renderPass_->SetIsDepthCleared(false);
+		commandList_->BeginRenderPass(renderPass_);
+	}
+};
+
+bool DistortingCallbackWebGPUOffscreen::OnDistorting(EffekseerRenderer::Renderer* renderer)
+{
+	platform_->UpdateBackgroundTextureForDistortion();
+
+	if (texture_ == nullptr)
+	{
+		auto graphicsDevice = renderer->GetGraphicsDevice().DownCast<EffekseerRendererLLGI::Backend::GraphicsDevice>();
+		texture_ = graphicsDevice->CreateTexture(platform_->GetBackgroundTexture());
+	}
+
+	renderer->SetBackground(texture_);
+	return true;
+}
+
+EM_JS(int, HasThreeJsMatrices, (), {
+	return Module.effekseerThreeJsProjectionMatrix &&
+				   Module.effekseerThreeJsProjectionMatrix.length === 16 &&
+				   Module.effekseerThreeJsCameraMatrix &&
+				   Module.effekseerThreeJsCameraMatrix.length === 16
+			   ? 1
+			   : 0;
+});
+
+EM_JS(double, GetThreeJsMatrixValue, (int matrixKind, int index), {
+	var matrix = matrixKind === 0 ? Module.effekseerThreeJsProjectionMatrix : Module.effekseerThreeJsCameraMatrix;
+	if (!matrix || index < 0 || index >= matrix.length) {
+		return NaN;
+	}
+	return matrix[index];
+});
+
+void ReportResult(const char* status, const std::string& message)
+{
+	EM_ASM(
+		{
+			Module.effekseerWebGPUTestResult = {};
+			Module.effekseerWebGPUTestResult.status = UTF8ToString($0);
+			Module.effekseerWebGPUTestResult.message = UTF8ToString($1);
+			var prefix = Module.effekseerWebGPUTestResult.status === 'passed' ? 'EFFEKSEER_TEST_PASS' : 'EFFEKSEER_TEST_FAIL';
+			console.log(prefix + ' ' + Module.effekseerWebGPUTestResult.message);
+		},
+		status,
+		message.c_str());
+}
+
+bool StartsWith(const char* text, const char* prefix)
+{
+	return std::strncmp(text, prefix, std::strlen(prefix)) == 0;
+}
+
+SmokeOptions ParseOptions(int argc, char* argv[])
+{
+	SmokeOptions options;
+	for (int i = 1; i < argc; i++)
+	{
+		const char* arg = argv[i];
+		if (StartsWith(arg, "--effect="))
+		{
+			options.EffectPath = arg + std::strlen("--effect=");
+		}
+		else if (StartsWith(arg, "--width="))
+		{
+			options.Width = std::atoi(arg + std::strlen("--width="));
+		}
+		else if (StartsWith(arg, "--height="))
+		{
+			options.Height = std::atoi(arg + std::strlen("--height="));
+		}
+		else if (StartsWith(arg, "--frames="))
+		{
+			options.Frames = std::atoi(arg + std::strlen("--frames="));
+		}
+		else if (StartsWith(arg, "--min-changed-pixels="))
+		{
+			options.MinimumChangedPixels = static_cast<size_t>(std::max(0, std::atoi(arg + std::strlen("--min-changed-pixels="))));
+		}
+	}
+
+	if (options.Width <= 0)
+	{
+		options.Width = 320;
+	}
+	if (options.Height <= 0)
+	{
+		options.Height = 240;
+	}
+	if (options.Frames <= 0)
+	{
+		options.Frames = 36;
+	}
+
+	return options;
+}
+
+bool CopyThreeJsMatrix(Effekseer::Matrix44& matrix, int matrixKind)
+{
+	for (int row = 0; row < 4; row++)
+	{
+		for (int column = 0; column < 4; column++)
+		{
+			const auto value = static_cast<float>(GetThreeJsMatrixValue(matrixKind, row * 4 + column));
+			if (!std::isfinite(value))
+			{
+				return false;
+			}
+			matrix.Values[row][column] = value;
+		}
+	}
+
+	return true;
+}
+
+size_t CountDifferentPixels(const std::vector<uint8_t>& a, const std::vector<uint8_t>& b)
+{
+	if (a.size() != b.size())
+	{
+		return 0;
+	}
+
+	size_t count = 0;
+	for (size_t i = 0; i < a.size(); i += 4)
+	{
+		const auto dr = std::abs(static_cast<int>(a[i + 0]) - static_cast<int>(b[i + 0]));
+		const auto dg = std::abs(static_cast<int>(a[i + 1]) - static_cast<int>(b[i + 1]));
+		const auto db = std::abs(static_cast<int>(a[i + 2]) - static_cast<int>(b[i + 2]));
+		const auto da = std::abs(static_cast<int>(a[i + 3]) - static_cast<int>(b[i + 3]));
+		if (dr + dg + db + da > 24)
+		{
+			count++;
+		}
+	}
+	return count;
+}
+
+bool ApplyThreeJsCamera(EffectPlatformWebGPUOffscreen& platform)
+{
+	Effekseer::Matrix44 projectionMatrix;
+	Effekseer::Matrix44 cameraMatrix;
+	if (!CopyThreeJsMatrix(projectionMatrix, 0) || !CopyThreeJsMatrix(cameraMatrix, 1))
+	{
+		return false;
+	}
+
+	auto renderer = platform.GetRenderer();
+	if (renderer == nullptr)
+	{
+		return false;
+	}
+
+	renderer->SetProjectionMatrix(projectionMatrix);
+	renderer->SetCameraMatrix(cameraMatrix);
+	return true;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+	Effekseer::SetLogger([](Effekseer::LogType, const std::string& message) -> void { std::cout << message << std::endl; });
+
+	const auto options = ParseOptions(argc, argv);
+	std::cout << "EFFEKSEER_WEBGPU_THREEJS_SMOKE effect=" << options.EffectPath << std::endl;
+
+	if (!HasThreeJsMatrices())
+	{
+		ReportResult("failed", "Three.js camera matrices were not initialized.");
+		return 1;
+	}
+
+	EffectPlatformInitializingParameter param;
+	param.VSync = false;
+	param.WindowSize = {options.Width, options.Height};
+	param.BackgroundPattern = BackgroundPatternType::NonPeriodicGradient;
+
+	auto platform = std::make_shared<EffectPlatformWebGPUOffscreen>();
+	platform->Initialize(param);
+
+	if (!ApplyThreeJsCamera(*platform))
+	{
+		ReportResult("failed", "Failed to apply Three.js camera matrices to Effekseer WebGPU renderer.");
+		platform->Terminate();
+		return 1;
+	}
+
+	if (!platform->Update())
+	{
+		ReportResult("failed", "Effekseer WebGPU initial update failed.");
+		platform->Terminate();
+		return 1;
+	}
+
+	const auto background = platform->CaptureOffscreenPixels();
+	const auto expectedPixels = static_cast<size_t>(options.Width * options.Height * 4);
+	if (background.size() != expectedPixels)
+	{
+		ReportResult("failed", "Unexpected background capture size.");
+		platform->Terminate();
+		return 1;
+	}
+
+	std::array<char16_t, 512> effectPath{};
+	Effekseer::ConvertUtf8ToUtf16(effectPath.data(), static_cast<int32_t>(effectPath.size()), options.EffectPath.c_str());
+	platform->Play(effectPath.data());
+
+	for (int frame = 0; frame < options.Frames; frame++)
+	{
+		if (!ApplyThreeJsCamera(*platform))
+		{
+			ReportResult("failed", "Failed to refresh Three.js camera matrices.");
+			platform->Terminate();
+			return 1;
+		}
+		if (!platform->Update())
+		{
+			ReportResult("failed", "Effekseer WebGPU render update failed.");
+			platform->Terminate();
+			return 1;
+		}
+	}
+
+	const auto rendered = platform->CaptureOffscreenPixels();
+	const auto changedPixels = CountDifferentPixels(background, rendered);
+	if (rendered.size() != background.size() || changedPixels <= options.MinimumChangedPixels)
+	{
+		ReportResult("failed", "Changed pixels were too few: " + std::to_string(changedPixels));
+		platform->Terminate();
+		return 1;
+	}
+
+	ReportResult("passed", "completed changedPixels=" + std::to_string(changedPixels));
+	platform->Terminate();
+	return 0;
+}

--- a/webgpu/threejs_smoke.cpp
+++ b/webgpu/threejs_smoke.cpp
@@ -2,32 +2,25 @@
 #error This smoke test is browser-only and requires Emscripten.
 #endif
 
-#include <Runtime/EffectPlatformLLGI.h>
+#include "webgpu_offscreen_platform.h"
+
 #include <Effekseer.h>
-#include <EffekseerRendererLLGI/EffekseerRendererLLGI.Renderer.h>
-#include <EffekseerRendererLLGI/GraphicsDevice.h>
-#include <EffekseerRendererWebGPU.h>
 #include <emscripten.h>
-#include <LLGI.CommandList.h>
-#include <LLGI.Graphics.h>
-#include <LLGI.Texture.h>
-#include <WebGPU/LLGI.CompilerWebGPU.h>
-#include <WebGPU/LLGI.PlatformWebGPU.h>
 
 #include <array>
 #include <algorithm>
-#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace
 {
+
+using EffekseerWebGPU::EffectPlatformWebGPUOffscreen;
 
 struct SmokeOptions
 {
@@ -37,227 +30,6 @@ struct SmokeOptions
 	int32_t Frames = 36;
 	size_t MinimumChangedPixels = 100;
 };
-
-const char* OffscreenCopyVertexShaderWGSL = R"(
-struct VSInput {
-    @location(0) position: vec3<f32>,
-    @location(1) uv: vec2<f32>,
-    @location(2) color: vec4<f32>,
-};
-
-struct VSOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
-    @location(1) color: vec4<f32>,
-};
-
-@vertex
-fn main(input: VSInput) -> VSOutput {
-    var output: VSOutput;
-    output.position = vec4<f32>(input.position, 1.0);
-    output.uv = input.uv;
-    output.color = input.color;
-    return output;
-}
-)";
-
-const char* OffscreenCopyPixelShaderWGSL = R"(
-@group(1) @binding(0) var colorTexture: texture_2d<f32>;
-@group(2) @binding(0) var colorSampler: sampler;
-
-struct PSInput {
-    @location(0) uv: vec2<f32>,
-    @location(1) color: vec4<f32>,
-};
-
-@fragment
-fn main(input: PSInput) -> @location(0) vec4<f32> {
-    return textureSample(colorTexture, colorSampler, input.uv);
-}
-)";
-
-class EffectPlatformWebGPUOffscreen;
-
-class DistortingCallbackWebGPUOffscreen : public EffekseerRenderer::DistortingCallback
-{
-	EffectPlatformWebGPUOffscreen* platform_ = nullptr;
-	Effekseer::Backend::TextureRef texture_ = nullptr;
-
-public:
-	explicit DistortingCallbackWebGPUOffscreen(EffectPlatformWebGPUOffscreen* platform)
-		: platform_(platform)
-	{
-	}
-
-	~DistortingCallbackWebGPUOffscreen() override { texture_.Reset(); }
-
-	bool OnDistorting(EffekseerRenderer::Renderer* renderer) override;
-};
-
-class EffectPlatformWebGPUOffscreen final : public EffectPlatformLLGI
-{
-	LLGI::Texture* backgroundTexture_ = nullptr;
-
-	void InitializeWindow() override
-	{
-		auto device = wgpu::Device::Acquire(emscripten_webgpu_get_device());
-		if (device == nullptr)
-		{
-			throw std::runtime_error("Failed to get preinitialized browser WebGPU device.");
-		}
-
-		auto platform = new LLGI::PlatformWebGPU();
-		if (!platform->Initialize(device, initParam_.VSync))
-		{
-			LLGI::SafeRelease(platform);
-			throw std::runtime_error("Failed to initialize offscreen LLGI WebGPU platform.");
-		}
-
-		platform_ = platform;
-		graphics_ = platform_->CreateGraphics();
-		if (graphics_ == nullptr)
-		{
-			throw std::runtime_error("Failed to create LLGI WebGPU graphics.");
-		}
-
-		sfMemoryPool_ = graphics_->CreateSingleFrameMemoryPool(1024 * 1024, 128);
-		commandListPool_ = std::make_shared<LLGI::CommandListPool>(graphics_, sfMemoryPool_, 3);
-	}
-
-	void CreateShaders() override
-	{
-		auto compiler = new LLGI::CompilerWebGPU();
-		compiler->Initialize();
-
-		LLGI::CompilerResult resultVS;
-		LLGI::CompilerResult resultPS;
-		compiler->Compile(resultVS, OffscreenCopyVertexShaderWGSL, LLGI::ShaderStageType::Vertex);
-		compiler->Compile(resultPS, OffscreenCopyPixelShaderWGSL, LLGI::ShaderStageType::Pixel);
-		assert(resultVS.Message == "");
-		assert(resultPS.Message == "");
-		compiler->Release();
-
-		std::vector<LLGI::DataStructure> dataVS;
-		std::vector<LLGI::DataStructure> dataPS;
-		for (auto& binary : resultVS.Binary)
-		{
-			LLGI::DataStructure data;
-			data.Data = binary.data();
-			data.Size = static_cast<int32_t>(binary.size());
-			dataVS.push_back(data);
-		}
-		for (auto& binary : resultPS.Binary)
-		{
-			LLGI::DataStructure data;
-			data.Data = binary.data();
-			data.Size = static_cast<int32_t>(binary.size());
-			dataPS.push_back(data);
-		}
-
-		shader_vs_ = graphics_->CreateShader(dataVS.data(), static_cast<int32_t>(dataVS.size()));
-		shader_ps_ = graphics_->CreateShader(dataPS.data(), static_cast<int32_t>(dataPS.size()));
-	}
-
-	EffekseerRenderer::RendererRef CreateRenderer() override
-	{
-		::EffekseerRendererWebGPU::RenderPassInformation renderPassInfo;
-		renderPassInfo.DoesPresentToScreen = false;
-		renderPassInfo.RenderTextureCount = 1;
-		renderPassInfo.RenderTextureFormats[0] = wgpu::TextureFormat::RGBA8Unorm;
-		renderPassInfo.DepthFormat = wgpu::TextureFormat::Depth32Float;
-
-		auto graphicsDevice = Effekseer::MakeRefPtr<EffekseerRendererLLGI::Backend::GraphicsDevice>(graphics_);
-		auto renderer = ::EffekseerRendererWebGPU::Create(graphicsDevice, renderPassInfo, initParam_.SpriteCount);
-		renderer->SetDistortingCallback(new DistortingCallbackWebGPUOffscreen(this));
-
-		sfMemoryPoolEfk_ = EffekseerRenderer::CreateSingleFrameMemoryPool(renderer->GetGraphicsDevice());
-		CreateResources();
-		return renderer;
-	}
-
-	void InitializeDevice(const EffectPlatformInitializingParameter&) override { CreateCheckedTexture(); }
-
-	void DestroyDevice() override
-	{
-		ES_SAFE_RELEASE(backgroundTexture_);
-		EffectPlatformLLGI::DestroyDevice();
-	}
-
-	void BeginRendering() override
-	{
-		EffectPlatformLLGI::BeginRendering();
-
-		auto memoryPool = static_cast<EffekseerRendererLLGI::SingleFrameMemoryPool*>(sfMemoryPoolEfk_.Get());
-		commandListEfk_ = Effekseer::MakeRefPtr<EffekseerRendererLLGI::CommandList>(graphics_, commandList_.get(), memoryPool->GetInternal());
-		GetRenderer()->SetCommandList(commandListEfk_);
-	}
-
-	void EndRendering() override
-	{
-		GetRenderer()->SetCommandList(nullptr);
-		commandListEfk_.Reset();
-		commandList_->EndRenderPass();
-		commandList_->End();
-	}
-
-public:
-	EffectPlatformWebGPUOffscreen()
-		: EffectPlatformLLGI(LLGI::DeviceType::WebGPU)
-	{
-	}
-
-	~EffectPlatformWebGPUOffscreen() override = default;
-
-	std::vector<uint8_t> CaptureOffscreenPixels()
-	{
-		if (commandList_ != nullptr)
-		{
-			commandList_->WaitUntilCompleted();
-		}
-		if (graphics_ == nullptr || colorBuffer_ == nullptr)
-		{
-			return {};
-		}
-		return graphics_->CaptureRenderTarget(colorBuffer_);
-	}
-
-	LLGI::Texture* GetBackgroundTexture()
-	{
-		if (backgroundTexture_ == nullptr)
-		{
-			LLGI::TextureParameter param;
-			param.Size = LLGI::Vec3I(initParam_.WindowSize[0], initParam_.WindowSize[1], 1);
-			backgroundTexture_ = graphics_->CreateTexture(param);
-		}
-		return backgroundTexture_;
-	}
-
-	void UpdateBackgroundTextureForDistortion()
-	{
-		auto background = GetBackgroundTexture();
-
-		commandList_->EndRenderPass();
-		commandList_->CopyTexture(colorBuffer_, background);
-
-		renderPass_->SetIsColorCleared(false);
-		renderPass_->SetIsDepthCleared(false);
-		commandList_->BeginRenderPass(renderPass_);
-	}
-};
-
-bool DistortingCallbackWebGPUOffscreen::OnDistorting(EffekseerRenderer::Renderer* renderer)
-{
-	platform_->UpdateBackgroundTextureForDistortion();
-
-	if (texture_ == nullptr)
-	{
-		auto graphicsDevice = renderer->GetGraphicsDevice().DownCast<EffekseerRendererLLGI::Backend::GraphicsDevice>();
-		texture_ = graphicsDevice->CreateTexture(platform_->GetBackgroundTexture());
-	}
-
-	renderer->SetBackground(texture_);
-	return true;
-}
 
 EM_JS(int, HasThreeJsMatrices, (), {
 	return Module.effekseerThreeJsProjectionMatrix &&

--- a/webgpu/threejs_webgpu_sample.html
+++ b/webgpu/threejs_webgpu_sample.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Effekseer WebGPU Three.js Sample</title>
+  <style>
+    body {
+      margin: 0;
+      background: #16181d;
+      color: #e5e7eb;
+      font-family: system-ui, sans-serif;
+    }
+    main {
+      display: grid;
+      min-height: 100vh;
+      place-items: center;
+      gap: 16px;
+    }
+    canvas {
+      width: 640px;
+      height: 480px;
+      max-width: min(100vw, 640px);
+      background: #20242c;
+      image-rendering: auto;
+    }
+    #status {
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <canvas id="canvas" width="320" height="240"></canvas>
+    <div id="status">Loading WebGPU runtime...</div>
+  </main>
+
+  <script src="three.min.js"></script>
+  <script src="EffekseerForWebGPUThreeJsRuntime.js"></script>
+  <script src="effekseer.webgpu.js"></script>
+  <script>
+    function countChangedPixels(a, b) {
+      var count = 0;
+      for (var i = 0; i < a.length; i += 4) {
+        var delta =
+          Math.abs(a[i + 0] - b[i + 0]) +
+          Math.abs(a[i + 1] - b[i + 1]) +
+          Math.abs(a[i + 2] - b[i + 2]) +
+          Math.abs(a[i + 3] - b[i + 3]);
+        if (delta > 24) {
+          count++;
+        }
+      }
+      return count;
+    }
+
+    function nextFrame() {
+      return new Promise(function(resolve) {
+        requestAnimationFrame(resolve);
+      });
+    }
+
+    function setResult(status, message) {
+      window.effekseerWebGPURuntimeSampleResult = { status: status, message: message };
+      document.documentElement.setAttribute('data-effekseer-webgpu-runtime-status', status);
+      document.getElementById('status').textContent = message;
+      console.log((status === 'passed' ? 'EFFEKSEER_WEBGPU_RUNTIME_SAMPLE_PASS ' : 'EFFEKSEER_WEBGPU_RUNTIME_SAMPLE_FAIL ') + message);
+    }
+
+    async function main() {
+      var canvas = document.getElementById('canvas');
+      var width = canvas.width;
+      var height = canvas.height;
+
+      var camera = new THREE.PerspectiveCamera(30.0, width / height, 1.0, 1000.0);
+      camera.position.set(20, 20, 20);
+      camera.lookAt(new THREE.Vector3(0, 0, 0));
+      camera.updateMatrixWorld(true);
+
+      var runtime = await effekseerWebGPU.initRuntime({
+        wasmUrl: 'EffekseerForWebGPUThreeJsRuntime.wasm'
+      });
+      var context = runtime.createContext({ width: width, height: height });
+
+      var background = await context.drawToCanvas(canvas, camera, 1);
+      var backgroundPixels = new Uint8ClampedArray(background.data);
+
+      var effect = await context.loadEffect('SimpleLaser.efk');
+      context.play(effect, 0, 0, 0);
+
+      var imageData = null;
+      for (var frame = 0; frame < 36; frame++) {
+        await nextFrame();
+        imageData = await context.drawToCanvas(canvas, camera, 1);
+      }
+
+      var changedPixels = countChangedPixels(backgroundPixels, imageData.data);
+      if (changedPixels <= 100) {
+        throw new Error('Changed pixels were too few: ' + changedPixels);
+      }
+
+      setResult('passed', 'completed changedPixels=' + changedPixels);
+
+      async function renderLoop() {
+        await nextFrame();
+        await context.drawToCanvas(canvas, camera, 1);
+        renderLoop();
+      }
+      renderLoop();
+    }
+
+    main().catch(function(error) {
+      setResult('failed', error && error.message ? error.message : String(error));
+      console.error(error);
+    });
+  </script>
+</body>
+</html>

--- a/webgpu/webgpu_offscreen_platform.h
+++ b/webgpu/webgpu_offscreen_platform.h
@@ -1,0 +1,246 @@
+#pragma once
+
+#if !defined(__EMSCRIPTEN__)
+#error This WebGPU platform is browser-only and requires Emscripten.
+#endif
+
+#include <Runtime/EffectPlatformLLGI.h>
+#include <EffekseerRendererLLGI/EffekseerRendererLLGI.Renderer.h>
+#include <EffekseerRendererLLGI/GraphicsDevice.h>
+#include <EffekseerRendererWebGPU.h>
+#include <LLGI.CommandList.h>
+#include <LLGI.Graphics.h>
+#include <LLGI.Texture.h>
+#include <WebGPU/LLGI.CompilerWebGPU.h>
+#include <WebGPU/LLGI.PlatformWebGPU.h>
+
+#include <cassert>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace EffekseerWebGPU
+{
+
+static const char* OffscreenCopyVertexShaderWGSL = R"(
+struct VSInput {
+    @location(0) position: vec3<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) color: vec4<f32>,
+};
+
+struct VSOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+@vertex
+fn main(input: VSInput) -> VSOutput {
+    var output: VSOutput;
+    output.position = vec4<f32>(input.position, 1.0);
+    output.uv = input.uv;
+    output.color = input.color;
+    return output;
+}
+)";
+
+static const char* OffscreenCopyPixelShaderWGSL = R"(
+@group(1) @binding(0) var colorTexture: texture_2d<f32>;
+@group(2) @binding(0) var colorSampler: sampler;
+
+struct PSInput {
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+@fragment
+fn main(input: PSInput) -> @location(0) vec4<f32> {
+    return textureSample(colorTexture, colorSampler, input.uv);
+}
+)";
+
+class EffectPlatformWebGPUOffscreen;
+
+class DistortingCallbackWebGPUOffscreen : public EffekseerRenderer::DistortingCallback
+{
+	EffectPlatformWebGPUOffscreen* platform_ = nullptr;
+	Effekseer::Backend::TextureRef texture_ = nullptr;
+
+public:
+	explicit DistortingCallbackWebGPUOffscreen(EffectPlatformWebGPUOffscreen* platform)
+		: platform_(platform)
+	{
+	}
+
+	~DistortingCallbackWebGPUOffscreen() override { texture_.Reset(); }
+
+	bool OnDistorting(EffekseerRenderer::Renderer* renderer) override;
+};
+
+class EffectPlatformWebGPUOffscreen final : public EffectPlatformLLGI
+{
+	LLGI::Texture* backgroundTexture_ = nullptr;
+
+	void InitializeWindow() override
+	{
+		auto device = wgpu::Device::Acquire(emscripten_webgpu_get_device());
+		if (device == nullptr)
+		{
+			throw std::runtime_error("Failed to get preinitialized browser WebGPU device.");
+		}
+
+		auto platform = new LLGI::PlatformWebGPU();
+		if (!platform->Initialize(device, initParam_.VSync))
+		{
+			LLGI::SafeRelease(platform);
+			throw std::runtime_error("Failed to initialize offscreen LLGI WebGPU platform.");
+		}
+
+		platform_ = platform;
+		graphics_ = platform_->CreateGraphics();
+		if (graphics_ == nullptr)
+		{
+			throw std::runtime_error("Failed to create LLGI WebGPU graphics.");
+		}
+
+		sfMemoryPool_ = graphics_->CreateSingleFrameMemoryPool(1024 * 1024, 128);
+		commandListPool_ = std::make_shared<LLGI::CommandListPool>(graphics_, sfMemoryPool_, 3);
+	}
+
+	void CreateShaders() override
+	{
+		auto compiler = new LLGI::CompilerWebGPU();
+		compiler->Initialize();
+
+		LLGI::CompilerResult resultVS;
+		LLGI::CompilerResult resultPS;
+		compiler->Compile(resultVS, OffscreenCopyVertexShaderWGSL, LLGI::ShaderStageType::Vertex);
+		compiler->Compile(resultPS, OffscreenCopyPixelShaderWGSL, LLGI::ShaderStageType::Pixel);
+		assert(resultVS.Message == "");
+		assert(resultPS.Message == "");
+		compiler->Release();
+
+		std::vector<LLGI::DataStructure> dataVS;
+		std::vector<LLGI::DataStructure> dataPS;
+		for (auto& binary : resultVS.Binary)
+		{
+			LLGI::DataStructure data;
+			data.Data = binary.data();
+			data.Size = static_cast<int32_t>(binary.size());
+			dataVS.push_back(data);
+		}
+		for (auto& binary : resultPS.Binary)
+		{
+			LLGI::DataStructure data;
+			data.Data = binary.data();
+			data.Size = static_cast<int32_t>(binary.size());
+			dataPS.push_back(data);
+		}
+
+		shader_vs_ = graphics_->CreateShader(dataVS.data(), static_cast<int32_t>(dataVS.size()));
+		shader_ps_ = graphics_->CreateShader(dataPS.data(), static_cast<int32_t>(dataPS.size()));
+	}
+
+	EffekseerRenderer::RendererRef CreateRenderer() override
+	{
+		::EffekseerRendererWebGPU::RenderPassInformation renderPassInfo;
+		renderPassInfo.DoesPresentToScreen = false;
+		renderPassInfo.RenderTextureCount = 1;
+		renderPassInfo.RenderTextureFormats[0] = wgpu::TextureFormat::RGBA8Unorm;
+		renderPassInfo.DepthFormat = wgpu::TextureFormat::Depth32Float;
+
+		auto graphicsDevice = Effekseer::MakeRefPtr<EffekseerRendererLLGI::Backend::GraphicsDevice>(graphics_);
+		auto renderer = ::EffekseerRendererWebGPU::Create(graphicsDevice, renderPassInfo, initParam_.SpriteCount);
+		renderer->SetDistortingCallback(new DistortingCallbackWebGPUOffscreen(this));
+
+		sfMemoryPoolEfk_ = EffekseerRenderer::CreateSingleFrameMemoryPool(renderer->GetGraphicsDevice());
+		CreateResources();
+		return renderer;
+	}
+
+	void InitializeDevice(const EffectPlatformInitializingParameter&) override { CreateCheckedTexture(); }
+
+	void DestroyDevice() override
+	{
+		ES_SAFE_RELEASE(backgroundTexture_);
+		EffectPlatformLLGI::DestroyDevice();
+	}
+
+	void BeginRendering() override
+	{
+		EffectPlatformLLGI::BeginRendering();
+
+		auto memoryPool = static_cast<EffekseerRendererLLGI::SingleFrameMemoryPool*>(sfMemoryPoolEfk_.Get());
+		commandListEfk_ = Effekseer::MakeRefPtr<EffekseerRendererLLGI::CommandList>(graphics_, commandList_.get(), memoryPool->GetInternal());
+		GetRenderer()->SetCommandList(commandListEfk_);
+	}
+
+	void EndRendering() override
+	{
+		GetRenderer()->SetCommandList(nullptr);
+		commandListEfk_.Reset();
+		commandList_->EndRenderPass();
+		commandList_->End();
+	}
+
+public:
+	EffectPlatformWebGPUOffscreen()
+		: EffectPlatformLLGI(LLGI::DeviceType::WebGPU)
+	{
+	}
+
+	~EffectPlatformWebGPUOffscreen() override = default;
+
+	std::vector<uint8_t> CaptureOffscreenPixels()
+	{
+		if (commandList_ != nullptr)
+		{
+			commandList_->WaitUntilCompleted();
+		}
+		if (graphics_ == nullptr || colorBuffer_ == nullptr)
+		{
+			return {};
+		}
+		return graphics_->CaptureRenderTarget(colorBuffer_);
+	}
+
+	LLGI::Texture* GetBackgroundTexture()
+	{
+		if (backgroundTexture_ == nullptr)
+		{
+			LLGI::TextureParameter param;
+			param.Size = LLGI::Vec3I(initParam_.WindowSize[0], initParam_.WindowSize[1], 1);
+			backgroundTexture_ = graphics_->CreateTexture(param);
+		}
+		return backgroundTexture_;
+	}
+
+	void UpdateBackgroundTextureForDistortion()
+	{
+		auto background = GetBackgroundTexture();
+
+		commandList_->EndRenderPass();
+		commandList_->CopyTexture(colorBuffer_, background);
+
+		renderPass_->SetIsColorCleared(false);
+		renderPass_->SetIsDepthCleared(false);
+		commandList_->BeginRenderPass(renderPass_);
+	}
+};
+
+inline bool DistortingCallbackWebGPUOffscreen::OnDistorting(EffekseerRenderer::Renderer* renderer)
+{
+	platform_->UpdateBackgroundTextureForDistortion();
+
+	if (texture_ == nullptr)
+	{
+		auto graphicsDevice = renderer->GetGraphicsDevice().DownCast<EffekseerRendererLLGI::Backend::GraphicsDevice>();
+		texture_ = graphicsDevice->CreateTexture(platform_->GetBackgroundTexture());
+	}
+
+	renderer->SetBackground(texture_);
+	return true;
+}
+
+} // namespace EffekseerWebGPU


### PR DESCRIPTION
## Summary

- Adds an experimental browser WebGPU runtime target, `EffekseerForWebGPUThreeJsRuntime`, backed by EffekseerRendererWebGPU and LLGI.
- Adds `effekseer.webgpu.js`, exposing `effekseerWebGPU.initRuntime()`, context creation, effect loading, playback, Three.js camera matrix upload, and canvas drawing.
- Adds a Three.js WebGPU sample that creates a `THREE.PerspectiveCamera`, loads `SimpleLaser.efk`, plays it through the WebGPU renderer, and verifies rendered pixels against the background.
- Updates the WebGPU/Three.js validation helper to build against the merged LLGI WebGPU validation revision and run both the internal smoke and visible sample in Chrome/WebGPU.

## Validation

- `node --check webgpu/run_webgpu_threejs_smoke.mjs`
- `node --check webgpu/pre_effekseer_webgpu_threejs_smoke.js`
- `node --check webgpu/effekseer.webgpu.js`
- `bash scripts/build_webgpu_threejs_smoke.sh --screenshot=/tmp/webgpu-threejs-runtime-sample.png`
- `ctest --test-dir build_webgpu_threejs -R 'EffekseerForWebGPU_ThreeJs' --output-on-failure`
- Generated artifact inspection for the runtime JS exports, wrapper global, sample HTML, wasm, and copied effect asset.